### PR TITLE
operator-005-mta-514

### DIFF
--- a/src/main/resources/operatorhub/create-catalog.sh
+++ b/src/main/resources/operatorhub/create-catalog.sh
@@ -46,7 +46,7 @@ fi
 # Build operator catalog
 # if version on argument is the latest version , not published yet, it will create the catalog from the community one to include past published versions
 # it will also mean the container image for the operator will be the one on the $user quay account
-if [ "0.0.4" == "$mtaoperatorversion" ]; then
+if [ "0.0.5" == "$mtaoperatorversion" ]; then
 # Create operator bundle image using user quay image for operator
 sed -i "s/quay.io\/windupeng/quay.io\/$quayuser/g" "mta-operator/$mtaoperatorversion/manifests/windup-operator.v$mtaoperatorversion.clusterserviceversion.yaml"
 podman build -f mta-operator/$mtaoperatorversion/Dockerfile -t mta-operator-bundle:$bundleversion mta-operator/$mtaoperatorversion/

--- a/src/main/resources/operatorhub/delete-operator.sh
+++ b/src/main/resources/operatorhub/delete-operator.sh
@@ -3,5 +3,5 @@
  kubectl delete catalogsource -n openshift-marketplace -l application=windup
  kubectl delete crd windups.windup.jboss.org
  kubectl delete windup --all -A
- kubectl delete deployment -A --field-selector metadata.name=windup-operator.0.0.2
- kubectl delete csv -A --field-selector metadata.name=windup-operator.0.0.2
+ kubectl delete deployment -A --field-selector metadata.name=windup-operator.0.0.5
+ kubectl delete csv -A --field-selector metadata.name=windup-operator.0.0.5

--- a/src/main/resources/operatorhub/mta-operator/0.0.5/Dockerfile
+++ b/src/main/resources/operatorhub/mta-operator/0.0.5/Dockerfile
@@ -1,0 +1,12 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=mta-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
+LABEL version="0.0.5"
+
+ADD manifests/*.yaml /manifests/
+ADD metadata/annotations.yaml /metadata/annotations.yaml

--- a/src/main/resources/operatorhub/mta-operator/0.0.5/manifests/windup-operator.v0.0.5.clusterserviceversion.yaml
+++ b/src/main/resources/operatorhub/mta-operator/0.0.5/manifests/windup-operator.v0.0.5.clusterserviceversion.yaml
@@ -1,0 +1,282 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: windup-operator.0.0.5
+  namespace: placeholder
+  annotations:
+    alm-examples: >-
+      [
+       {
+         "apiVersion": "windup.jboss.org/v1",
+         "kind": "Windup",
+         "metadata": {
+           "namespace": "mta",
+           "name": "mta",
+           "labels": {
+             "application": "windup"
+           }
+         },
+         "spec": {
+           "hostname_http": "",
+           "volumeCapacity": "20G",
+           "mta_Volume_Capacity": "20G",
+           "docker_images_repository": "quay.io",
+           "docker_images_user": "windupeng",
+           "docker_images_tag": "5.1.3.Final",
+           "docker_image_web": "windup-web-openshift",
+           "docker_image_executor": "windup-web-openshift-messaging-executor",
+           "messaging_serializer": "http.post.serializer",
+           "db_jndi": "java:jboss/datasources/WindupServicesDS",
+           "db_username": "",
+           "db_password": "",
+           "db_min_pool_size": "",
+           "db_max_pool_size": "",
+           "db_tx_isolation": "",
+           "mq_cluster_password": "",
+           "mq_queues": "",
+           "mq_topics": "",
+           "jgroups_encrypt_secret": "eap-app-secret",
+           "jgroups_encrypt_keystore": "jgroups.jceks",
+           "jgroups_encrypt_name": "",
+           "jgroups_encrypt_password": "",
+           "jgroups_cluster_password": "",
+           "auto_deploy_exploded": "false",
+           "sso_url": "/auth",
+           "sso_service_url": "/auth",
+           "sso_realm": "mta",
+           "sso_username": "",
+           "sso_password": "",
+           "sso_public_key": "",
+           "sso_bearer_only": "",
+           "sso_saml_keystore_secret": "eap7-app-secret",
+           "sso_saml_keystore": "keystore.jks",
+           "sso_saml_certificate_name": "jboss",
+           "sso_saml_keystore_password": "mykeystorepass",
+           "sso_secret": "",
+           "sso_enable_cors": "false",
+           "sso_saml_logout_page": "/",
+           "sso_disable_ssl_certificate_validation": "true",
+           "sso_truststore": "",
+           "sso_truststore_password": "",
+           "sso_truststore_secret": "eap7-app-secret",
+           "gc_max_metaspace_size": 512,
+           "max_post_size": "4294967296",
+           "db_database": "mta",
+           "postgresql_max_connections": "200",
+           "postgresql_shared_buffers": "",
+           "postgresql_cpu_request": "0.5",
+           "postgresql_mem_request": "0.5Gi",
+           "postgresql_cpu_limit": "2",
+           "postgresql_mem_limit": "2Gi",
+           "webLivenessInitialDelaySeconds": "120",
+           "webLivenessTimeoutSeconds": "10",
+           "webLivenessFailureThreshold": "3",
+           "webReadinessInitialDelaySeconds": "120",
+           "webReadinessTimeoutSeconds": "10",
+           "webReadinessFailureThreshold": "3",
+           "web_cpu_request": "0.5",
+           "web_mem_request": "0.5Gi",
+           "web_cpu_limit": "4",
+           "web_mem_limit": "4Gi",
+           "executor_cpu_request": "0.5",
+           "executor_mem_request": "0.5Gi",
+           "executor_cpu_limit": "4",
+           "executor_mem_limit": "4Gi",
+           "postgresql_image": "centos/postgresql-96-centos7:latest",
+           "web_readiness_probe": "/bin/bash, -c, /opt/eap/bin/readinessProbe.sh",
+           "web_liveness_probe": "/bin/bash, -c, /opt/eap/bin/livenessProbe.sh",
+           "executor_readiness_probe": "/bin/bash, -c, /opt/mta-cli/bin/livenessProbe.sh",
+           "executor_liveness_probe": "/bin/bash, -c, /opt/mta-cli/bin/livenessProbe.sh",
+           "tls_secret": ""
+         }
+       }
+      ]
+    capabilities: Basic Install
+    categories: Modernization & Migration
+    certified: "false"
+    containerImage: quay.io/windupeng/windup-operator-native:0.0.5
+    imagePullPolicy: Always
+    createdAt: 2021-01-11
+    repository: https://github.com/windup/windup-operator/
+    support: https://issues.redhat.com/projects/WINDUP
+    description: MTA is an analysis tool that supports the modernization and migration of Java applications.
+spec:
+  description: >
+    The Migration Toolkit for Applications (MTA) is a web console application that supports large-scale Java application modernization and migration projects across a broad range of transformations and use cases.  
+
+    
+    It analyzes application code, supports effort estimation, accelerates code migration, and enables users to move applications to containers.  
+
+
+    For more information please refer to the [https://developers.redhat.com/products/mta/overview](https://developers.redhat.com/products/mta/overview) page.
+
+  version: 0.0.5
+  maintainers:
+    - email: migrate@redhat.com
+      name: Migration Toolkit for Applications
+  maturity: alpha
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6CAYAAACI7Fo9AAAkF3pUWHRSYXcgcHJvZmlsZSB0eXBlIGV4aWYAAHjarZtpdhu5koX/YxW9BMzDcjCe83bQy+/vIklJlq0a3uly2ZTIZCYSEXGHANLs//3PMf/Df7XmbGIqNbecLf/FFpvv/FDt89/z6my8/97/Tn995n5933x84Hkr8BqeX/N+Hd95P31+ocTX++PX902Zr/PU14leH7xPGHRlzw/rNcjXiYJ/3nev303zzw89f7md199Q7ik+Dv7+eyxMxkq8GbzxO7hg77/1uVJ4/nb+Zv51IXEg//Jz5BO9X3+fP/MxdX+YwI+fvs2fna/3w+d0PCd631b+Nk+v91368/zdWfo6Iuc/ruy/jqg2/zm2b/N3zqrn7OfueiSPWsyvm3rfyv2JAwfTGe7XMn8KfxM/l/un8afabicTv7jVYezgl+Y8M35cdMt1d9y+r9NNhhj99oVX76cP970aim9+BoUg6o87vpjQwgqVaEwiFxSXj7G4e92m63GxypWX40jvOJnjG7/8Md/f+G///HKic5Tmztn6MVeMyysJGYYip385ioC485rTdOfXmefFfv9PgQ1EMN1prtxgt+M5xUjuM7fCjXOwyXBotE/Ku7JeJ2CKuHZiMC4QAZtJbJedLd4X55jHSnw6I/ch+kEEXDLJL0bpYwiZ4FSva/Od4u6xPvnnbeCFQCSKphCaFjrBijHFTL1VUqibFFJMKeVUUk0t9RxyzCnnXLJwqpdQYkkll1JqaaXXUGNNNddSa221N98CMJZMy6202lrrnYv22DlX5/jOG8OPMOJII48y6mijT9JnxplmnmXW2WZffoUFBJiVV1l1tdW326TSjjvtvMuuu+1+yLUTTjzp5FNOPe30j6i9ovpr1L5H7q+j5l5R8zdQOq58Ro23S3mfwglOkmJGxHx0RLwoAiS0V8xsdTF6RU4xs80HE8AtRpkUnOUUMSIYt/PpuI/YfUbux7gZZvffxs3/KXJGofv/iJxR6L5E7ve4/SFqq1+4DTdAqkLmFIQMlB8HdV/5Hzr58ZWhpbIKM7hsX2OeBVYxuSkwBDNWarXuaUvpJ3SO237MnTMwC7rZmGqBTubx/czV9uGy/sRZcp+9p1xTOMzKMhw3idmMvLgVxokkai6jVb9yIHgzHqFi3Mx53Y7PVvB5tLJi2Z6zlDxzmGYmwl6KLzcS8cB6vYU6yx6J7/aex+htjzjt7q4AsdulOnwf7rRUwoI0R+jD1F3qKic7t+HMWbdtaTPqs2vpKe0y0x4j53SG3a3YmQdTzgQVv2M7jMYPm89hsu/4mj9l7pTGJNC1R0cQSfFEOqw29kGFbO4nMOWtp1pJi8WMtRTmOEJzQwltppnZ7fW4sMe25cyaT3Jn5t00uZM8OyS7hs5IueFLaZHiqyvH5VI7hjOOttzm4KPIDD7Sl2ukHo5+6nbtHu57DljfIRKfSD414Nu7waQfeK0XHeIUS898NQr35BCPZnLNQtbDcwwutpx27ETArzmTqyR2W6RidnuvU0w9pE4aK5fjSmfCmZG1eprUOVmeuOYEncs6oZFoiUkiC7zvZFImaPHOUVhmM0eplx3L6Lute/UwCjeb02h5ROVCj7MTecihzl1O7Lt7q1TjnoMnQseZOatVruXt6s01P3b2fbnlT1ornpgBkXjGbGiECb03so1CpRKbSysoIc7I3FrIg/HY3LlSIlphC4IGY4jkBbdTWw+V2aqO96dbi+IffK2MMscKbvWxnCHvnzos+dZh2NRhYjIXBzlAZlM9uW/Om7rjKi6XOmq9dXVj6VBxpZgNPi0Xk0sdZNEPMUkl/v1rAr9WHosJro5by9ufXVKcFTYMkxIHYVaLpTCjLYACg8oKFtl5/ExptY6aIQnHjMtztJ/F9WqYw4y4FHRw63eoAAnZC8rVTPZCBRJEa4LBZ7WTQL/DCXfwgyCHSQaSAoYpi8RkcKocOUePh3TKmxMTmZmJQDmlnViqnw3xy+/pkKy1bfAz87eng6zZXCC2djwAy4czc5qwMBJCRmZ2n6Fv4C0Y24OWrqY7V9Z+eTXf33he4xHWl5QRTY20LJAbPyFH6gTaQEDKO+l4T7Qrk2VAzHlSPXaqEmsvi+/1jdyCrbZNIBQ0eUiPnkoPE3WYIEo/kYPgWyQHPFmyTXSUcfWDubGjUA3kMCIz+O5hC2mefaLdS4oYKSJNHDr3SuFQP70xf0xAKMbfL4fuetizjKP8OD3uAUX3hSxtHVjyUKslOrt2pGkszbUpgwGQQCiWokAfidgcte1JWAqYWQ3PrDaI5IdEPLoQWHdII5Va9cZulG+k4iSRS+b4RsWTdojz0SZyPpCQaHAPHsNKTBIFsToM6g8DZczTD/CIn/B+lOq5fDA9JQWrJLvKPmGvUE5w3OZE3MIftmAEzybzqGTQgSokrVbqRgNjutqBi4guwSoMn6KBlIhwAxIjU+QgowDgVyCWPGZ4m1mlQMBs5ul4onZvvwS3m/1Dov3T118S0iFD/Kae0SvcmF0rwQGR8OyM7DiNq+NhgOh+Esw6yJes2uUAwg9PMxUZNTOr+HeRT2tHgtLFA8ydUFM+JhIn+JUog/qpw5QcQIw3gGiIHORFQoLNCHSmmRlGZ3Ak46HwdhtDeaismJZkFUUioqA6KmhLUw3gwAQoNDHEiiyrIdkBYIcCK+9gVwtu6NSAHjzec+ujX/3kcGzk9iivKab64y1olBOMGQDVYxWLYZNwc3B96ciEIgB/jktAL5MRKTBopeRmEYl8vKOB3hAeIAZo7dFkDb7GMpJ8fUfAw8519Q68V5hYdAlv8O0xToY1IB7ExCGzgfkzCuibSPEnE7j6+dcZYH48ICYAb4FhzwtCmLoC1netz2zAjVQLlyyCEwN4oEMoRMCXIuPX0E9RD0SkjgoncyZoXwpKHswP3Da8GTwoF5giyhwxk7ahNFBwoFCkQjBfAxfb8GltoOJ6nmJwHQMTeyqGOpU2plTLBDOITep9TWBkX8QYZBjS7QrXyXS5JdRB4gClV7hemQf8LxAOPkc1N7EwAYHPOrLVdHCyYNzweI3YHEADfdmkW7sot/cyZBkc6YlSPwupF9FSQB/ikCxHu4R1kkGMF2xiKZPEnCRbcTLw4SI788iESA5szXn6KOv5zr6PV/P9je+vfSFBO2qho2U4e8VBICA1TSmS2UxE5BjEaLoqse7Q70+ICZewXoCjz7o1nBI1gQhCJE1U2HDjzkGOWBSpCSRILtagMjAYMOJYBQquGBYFY/PN4CfqAByV6kakIARBg61YlDJwUw7S3XEgVZMz0BS+i3EiEjJwWClsqoSvob+6q2ATOmJh5X5P0YSOLhlVxadPZmPf8gdREG0IaO2JSrEMHs0JfVY3M6cmgIoEF0STkMp2+UuxwuzoCClzQ1RBtMjhjrmBqYMoalGzGDISh9LEXiAqUI5oTJ+VNx49hADJiFGMIXoWhKoolsOcUtUtgkeWcU8EJOkyLNwIBOAGnUtzbmgdaMTwYJtjhS6XGQ4aEhjhIISHzAl8lPc+idhP/GyzElqBu4VHQJUyPDKBsSck1vSyzO56kdTIBupaPcpIIQJcp19zRB5MAA4f2S3ahOy2sTvfVRr1jTlun/pmEbcH8+qgjQ1vVeaio9coF8mTjNdlnmAF0t5V4JL8qDujkMej8OIiO83qlDwp3zH4SH/0APRY8zUz3ke0/IEP8TQVQOS+IMviEG4wwtkTZD1dmGwNE52RIcgwD5GA+r25jApJZ0JM8oHVQsYFlYOVXdFBIcMx9XjiK1y5hJfO1oFHxsPquprWRRmMxQUbDo068DV57oIpp/6S7bVZhBhqKRWKmGJYgbQycnqwGpiCtEPTzYa4CxTN0gBQUxQtrEK59RRhShwEdBGuhwZacploBAS+obYHloYUcvNUi3wPOL+MOSR1KC0IdPa6lfqTadugHdqMiSSGFJyFDD1SAqi95pNpofAkDJlEsiqThTuioTRbA27CGCF1qpiINOvAMpKwcU/ebez7afAaku0cckdxilZ2fiTEK9mIO4EoDleF0RMqUK0CcESNieao7w2cWPQgIzFk3UAODAyTaj3HqcGRM6BEOtwKteQXHhjiiPgBbG7AWUsuD3RyU/GdWoN58gWbeZZVniIuGTVTIj88qoPtB5y8tkYYKhokFDUPcCm3K8GIMgAKi4gvxsLbYTsQiUytrx4GGbjF2Rrn1AnIKlQtrnOcyOCR8tRkCAoLkcaUGfkeXNzMUfTeEjc2071Wc0U1IJ99lruvRAdWme5+nhitXgc5faT8QaxwJBYr2NmU+HDjICcPJ26V49QVGUAYgeU2iWyKUigUeoV/Gq55NxLSUubk+KDGiC+0uTalBl6omVyBmoFar8VbdNXHaC3FvO64yB69oo86FYFEPdIzJys/5v2o69woWioGJ62mBDrnGvWV04obQc6on5I81RBS7PmTQ/A9Z7s9hwU5LDB3Iej3VoIDwyG7KllKSSwpiKKGkwgfrDJe+hDbXdACCTI7fD1N2ZszQbqCv8MFzYgwQwggTgBxVChj0VxyZe6o59qNh0MYOMoxUYFRXTpbckZEkifyMwWWhywRZgwQG8aAqLOapGa6HTjFbSe+n5gswNtxO6B0JQ2RAurIgcwYeiiES/ub4EunO2Tv+3TqoGzQgCEwIuQvogdrKv1Zt8+BmoTU+fAKHugrflcElDvyOQWoYUC0vdZk4PeakReg5kIK+3PrB0WjLjC3AwYOIEpt1A6FE0pQrc4K6k7VDnxvQTbk8Y2YpdBjlPqhmJiA6TKARemiA2CGLsVGAVPdyONcxPNgHgKlkc8D975JSED9UPqzZLsAbFCFtG5qC5AJU5oYUdBBvXpurynj9jF05BNKg/ugPP2ohnQAprC1TP6i0luQ4KKC1V7Fu6tPiNifIbrSEtm6XjM2b1/z6XaGtUwgqZWGcEdTUsND3d2Wk4ZwQQbwIIOHlKYfvx+uGmjdvL8Bsry+QT1fdUoKQNxOrTSSlvInexai4CD3R8oM71B/48qzjs1iqjouat1J5+AGSQBpx/FGvDrbff/Sn75jvn4pClnslOyjDNW5QgShcE4ja/YjDMe9eUw8UT/W3eJ0PR9YZL+ahAFLiJW5V/FIeu4SD9BusylyQsDmEoYg72EMqx6exgRnmN5fzR54pYNS4MjAZqOaFyPuhFrME1UhDIRkJDpRkANdP2OURbyyZsY7kdixIhqHwdValld4khU1uVwqwILX4pluBq18P1HHDsolv6ap6m0djCuKhkHkQwnt2yivi9mB2oeIEBisulnvz6NUoDa1S2MaCO0DHYErndmBItUii/iee++dCd4al29FNdLieK7MaCOzSug0h4yU++L+juH2MRv3y1sjoEwGmXMvr4Z+VLN8CyDRL0JGAFVxdG7PO0dIjwezMer+DnZMdRWVtShETYS/KwXotfy0BZmD+kVFTxhWMNrAZI9d937/Wd8vxAr2WcseSAC11tDCPX4gKJDzCXnZCEK12rnUEfLKf4Cta7kBmgrhCGAucCPasjoJYBOHV/vhJ9RvQESU0Bla1BpLcddP4FCmvLIA9Gf8LN/w0whANTWACIrFK4gQxmAgjCOjJmF2oRhzHTh7FuEgFZViw6rBTo51pLZ2IKi5NTDCldys8pwHPhvoKQQRzhKeddI3fHshRFAVag9oCYNhcQFScC5qTWAyRWrwSZsyqrjXW1+n3SK4wljLF+1gi6X/GRHq99WW7PFCnbmscEr8O20drrZ2V1srxSpC8kQ166dcezNHXTCQHxWBe8hMtx/QA+BZC8XLRHvZboztpH6jllBwoh6g1QLUXUNkCgC2JcVIKsXs2x7dbcTloZJE8whHiBimLIwKWGQUGQ8KdzNhJaMHPfKr1UramOxDxwjYvMEH4AgxVFGc6olGMsXjcUivMiXZNImkbssSbnDtdcPB4nhDMrgk9EURdY6MxMYkKKvBgqqGk2QUIqRoBQbTjgEV2Q/oRouEAASDKBjVSWbf9XlUWI6CI5ht5aIlIG5B8SkdvoxaeooQMiC799ReAy2VSLatH3V2KRXxIFu6PROBGRXsi1L7RDgJ0NFuSxax5oAKpBiOM06+zhVUzsJsTYwel3N5c4BKLaFsCB4T0icpynBbjVMiHbfQYyb7ojoXG3c0tKDjHlD/jreix1sOwlvKkbHKNDT88oGbSQ2/EEkM2EjqY8ZJS86w0GqnyrLCZdtJLG6RJLoBmRq4QK2WMFIiwkay2mm0DMmaWTBTjN5xSfTaDlyzoW3Wv9Tb5i24s+rPaflPk++w70mWPCdBoerTYQNRIThgBod+1UIDBlYkWceI14uAsonkKAs3ENpAeJHlUUv7aEhcPI4CKNg9BqwRtbeIhhMjUYqd2cDak9mAcmfuCxDP9wk+uAArUUH4GaYU0wE/5REY8eUH7SCSuiTZyVMtv0iHYmr6bBhsuS4rW0e5JxuYUfVG410zoAzEG0huJNmLNSIplNQYSbXCe8sMsW+gUJr2ntToI8r+Bj6E8SDOUHe3/taiGqhaxJKsKDrcLHxnVJuKUojqkuNrtLJ9wP8ENscp7OoYBc9MAwfNt0ladizx+NKWMun2pRrcBnxVoCElteHsvZgHh9AYlCkubHjwIwO7KEwgecwguXF5BAg2uagxtd6NKfGI1uDTcjJEHIEZRjRk6SDG5XLgeu2zO3WpE+AxGC+0vcN+qydRH+skgnjQ2oOG6koAmzdd8isxa5E0Uzfu3K4PFoJK0NIepBCBZcJJnRSt/MXxFprfuKG+TtZe4pBBO8xxbU2ej/OVj6ES1TfHU/LaOMBsYFEcZgR1jd++g4roYq0tEtdkqGGHPQ+RQssLoKmIalBlkPqg19ICMKR7hRVCB/DrVmivxvDUKhc3lOERpJ9axTtbWAt3iSo7TjuWCvJpMKaMbaWkmL/rtTshh4PgVhkyGLJtrao7JruJBkoEBBYAdaBnSUjUSq9AtGsgYhq6ezAlOrDqJC2oNuYkhqmFiw5SW4N6RXL6TaghtaYFNqgbQnRqqs0Q5Ngc3AgQDFK1X0SoEdCPpDglXe1CEJmWyEQvfF1Mz6Tk5lA/RzQQtQ+CiCzIimgAkU7N2sNko5tHD0JwjDL1ZQ24vNbd1LHyI/fSo6VtkupF/UqqqnoRJygyezc2kOy5eG1VgfdgvFOMhajD0dYPdUy7Yl971VI8oSPDofdA+WkjylJLT0sjJKHTTOHhoI29BYBmTlKvSNa1gfU6vQygMHURL8xHEEZIYxOmuLx1U5upEoQ/KS3lBaTcARZrgKEeteQyoRmk0gHPljo3meuS7lkbEUS/E6WWnJ1tcHdorwYJ7pHA1YRySAbwGLpfdAIJxK1AxmH5R8W5ebwad15Yge8kjlBQVptJ6H/718w5uvAY9IUWVmE+PBL6AKWEguIT30iDDVBeZxuvKLK1h+yrhCxWAApH5yIwRs7biFIDp8aOcby9YgvYgWHwh5R9u2ZZnCMgSRES58oMKGNFMoiu/RptLooWoETsFKEAF8KsonHBBRJGzSv4/jAqnLNcJU50XyfabjcmvozrTsVocYVP4tN3lccQ0qjh8cOXcOIAsBaPgVamySEXRptGq1vTJ1RZKQ/k9/qCfLD9j6sTWqVJIFcdKK6d0F0Z8B+kkLbdeRknGAwZJ5/AkObozEVKgA+VUbK2/dx28jMXqQWpKJKqTKD3Mm1GGTLT1+1IcZA4ZyFkShkeB0B1gmfaQDK0PJ5AMkyclmUXjitzh4TbRLREBOdBurUn9SnncO7qBlwgr55a9dMJZxANXu3A59at3MMLz081fwD09uIDgOzFBw8biAu6doKimUgrZIKgSLQdVjXADzovKceUb9JYyHzInjJGZGe00Mgb8Nm3D+HVH5RjabDomNexdLfGMrIs7c7OY1oUK9yhVs2gDUTuNSHa/YRdWfZPfRFGYt2rxUpWfrUNoIQT3iLhkGcRR3QAQooPaiHmqJL4qJIpt444u0ILQdj3VY4/9EPS0w+BbSvf52QUtXwuok5eqnlAAHfkQ35aK9y0VtXTXcgIj+iL6g3fUGAYySlYsz9DbcrfdHC/TXttOJFFcJMgZzE/OIUT8IjhR7g9WHzdInhnpc6fDiZK2RxQP0qtIVN1jemeboeaIfKVU7c376LhuTqOMKAfESnwEGWYuG0UyTEiZO4/FuUL90+ePj0QahZ/p4aF1fYvbUASjPEx6ghFwT2HtyTH6mmONOB+cgtH2I/QJgHQPNf7gJwSTIwK7YXe0fjS7ZkzWVlpXR6JbJ52yVsiryhR8aTEeHVjStImnHoDrvZH+mh/pCcJtOTrDG5fd0Qda48EYboApVXJ+Jbp+7nqTyD16rHtZ+H4v/jqezwABBNuiNadZG5KCTKflWSYfUJFv2yKJJ5OLmRjLkLTnjLKl+8x2405kqA/vRHv2OVgQTCtbECzDcwiKiMLDME07VMoflZASSdAM2txvN09JKhapIaaRskCU2obx6E9e/aNUvjIB6Vcx/qgmmD1PUlrKqPhygvwhybb1ail0q94VUTrFa8D8WrRGnANnnat+tKuWrj46Pq8Ohv2DCwnYhQdih7zM+WNCNO2VNQ/MCwbEtRCjh+tk6au5MZSHAFRRJ0IiDAgwiFUbbhtkIreetogT2dWnoOSf7YMRop1YyNwyRD1bTFbfAC/q8Vs64Fpb49ZjfcVRglw8EpaZgDq+aN9vGoMqIOtDU9Tu/bQtVr1WAstkBoWN3gkkVGQ8BAlSztC/5Z8RQHPumEjLqudLulNdhs8PF+gEelzkE4qPD15UD1oMamvql4UIx8UsITeKMq+5mfzWgLFvPrqro1s2mFDsZBb2vTG+QzXrWqfceMB4iJAOM8SsZKLuGq3K5KrJ5wfqXEb3fKTDSW2MraDBNfylw9mytpZcWBEfJ7bhgNx9tJmloGxTdoZKWj1dykmL7+QxiVEbTdZEDDu1PZupnb0gGFIZ9wWLjjoM6zI0uZCn9W2chRGmSVo+0tmRNgpiTwtAgfrWlGf2aDVhvIRG8z9aAed9tOov4PUR7JSAkibc+kSkk2Y5IrJqSlCVNo1LdmKVjfPBgZEGtCHqLGPuJHZYAZsjVttUpQVYgAKRApjaWC73mQ8YIp2tz31YaLi6zmcIEOy0PmmABiHdu3AmOpRolAnEZtxjRy1IaDK91sZQw7AC+CjDRlokdT493Dw2MrCrF4EZLEw5ExKCaLH7LWHtmg5EYM6ie7SklnFUFNIJRk1YLUYrPXKmKrWKym/1oo2RlZCId2qHa+nbnXL9aSCD1yqU1pDG2yL3chqoy7YRUNkedHCclzaumBzu6txCzegBSePqCZd4IahJVzsNtU3taeZearIB7PVo0UEL+1hQrVwE91rRw3udyPkABak7sb7XOv3J9WL9nPIGq0rTe0QpQRtxiDBZ7UuNf580S7sE3BRGi/3h+oVEVKbzCYav5CM1DUJYfDhh3CRrQRTa/74ZFwk6bLBmy79zhTgTgrltjPlOJ8FjvZu2T+LD+a2zdX+mO+eFj+AEOFx0Bw1o7zuxJuuSP1qFRBMAI0qoWyyopmCRUQEmSFxONm38GNtwMQe7GXOiFRFtxVo8YLbUNZDs1GL5aS2trWCicTvCi2E/liXiQUaucrPu/gs8KhV1nEZQrS+77KeVjXVAteGhsR9ImQ7CLkF8cynFjKHGjug0bOFFXRP5EOTLgexszYggQ8x3XKRj9QuR2ygjoSyX/KcsfNzF5hAtQjDX9gMGM4+iagKTk/2q5D42tQBn4jNzENnL9WdlGkyNYF7rdr8Eb8o83Qp7y3MKXpiJ4EJFRD+rr2EURu97zoATAiFaM1q79f+qUkm/P5Aw0HdoYu6WloF4qLW1BgZ1D/1CFBCGFu9iaHCyuriRbuI3tC+9J7b3emdc7uPCchP4hEgi2FIfj3BoX1SUXWsBkqMdbje8kaOBfySiB7ehSwp8Ka1zahmQ2F2WtaO8Hsi9ZtGvzvCs0epB1+r9qlyHXUNAGHtAk1bS93acaOmnRrUTLW63Nr6hfHNJsBFYzhxeUKUMCzc0wa9eO+oLhga6gTPd0LR0g08xN1AWNqffPet4cUs+ijf7VLFJXt3rSWydm93t+3+vmuta8OnovC8kDeM0PlW4nsXa3Kt/rgRMVMo4e7dWM/aFrzLWVAvmGRJIbSN9rFhUDtqxuKCbAesxNoO1RWXTLLILWBjM2kcKK1fXejGWKKWvDVXezRt34pPoj4p2D/M4SQFx68piI+4qit8qK7iDbIrNXuTmeR5MlVwcN556v9ZmpqPfB0uB9Xv0abLLtKBu6OtSqSqvaJAqVbF7KI495S81XY0O3vW/RjustaiDdQzYb32azua+9yONhdj1V7Z+0wiYd81tFSvDkP4Du0SyBAkSdGujKgEFXqtA0O79gja89jeu8PUjFZrXAp58lOZFvgcKXp1erPfehRGuzwGJavdQCCrCLM4LS75Xu8GUYQefrh9bK8ltm1rhVw5oM3yLWyTustMm4WktraCBzWk89T+dQ6BMDgopKiN6V6LuGqxP2ub+Bnkr3aGe6Smic+rkh84b0T2vW4GGvi/23b5+Wr++gBtkgSY71bXeSyOmeEH7/WEqUcuMi2Xp10xW5Sj/auM1F8ViJWZ+NelZ4YytCB45bwAu7at2mwRCOAvqpcb8DOTFila4xAKToDDNFDJXJeMzVC6n2XV6DZY6OOXPbOfm0iGBDySQs1zjF+MqEo9k7cYM/nk7l7qnLXYGZMnIgAiw7xP2QGVWw9CKe8dPBOlkLKeVjEFmsGHTzttAWxQKYfKsys/UUAmqHM/tZtJ7Th17nt2MKLoRwgIV8LwwqO7xbw4uXJwk9PpFvTg39EOMPXva7it5lWpBcYUrgdtV9Alsf3oatZxCMhuQVrgROuAWG6EyhUxKL4vLZ6/zAHzj5LkNbl3T71DncwYuv6CzsjLI7ozNlbSdKmRz9ygyw5yB+eVyWU9eHXEVFRt0zLMwLtthwy9uunuK1r3aY7tTMWV26G1b5iUMsTNMIGAYUHbODUTnDpUGKquLbBRa6ulDMoWfwYcyPpOLdTh6UCXpl3YaihB9ONCxhlZBQh3zEp2aB/hnlm7AJVQCmnKEX9I7CSXQMj8xjzw4HfYx6A2Pc0RkId60BIpZKs2AXKRpm0jwjz5WlOiHl36knk4mCqtM0hcPSKnJ5+0o3x6hP3QLT/PtSA2+7jPtThufhnwKh2MxbL3WZln68DzrIxN2izl7s4fuQfkOZh6inbpPo/cYAUC7pBAZVOW5DvmHhTNjJWiPEEyVe0tIrdL0/4TMJAp2tAZCg1AXjtVabXsuRlAHcUmaNbDFlAraoqax3q+n0z4Zw9p3VcjrMtaydEuYT1At7UDNOmRJosvVv+1bUHl5ZD54hCxVVAHR45pIQ8bvKbG4Dxk4SmdKp1VT87BWlnNYe7vzo1VU62TWV4PziEIvTrnzM3Q4oXvJKT32s6RvdalKUhKFGMZrNq8S2sFRduvtbTYpIpw9iAHIIf+D9Q1WY/0Gd4ZeSSt/jeLZdVzK5Pixbyv0xu8feXteaffUfpFEef+nn3m75+XcHoYN9cAVnAferalA6FD7IDA3+qBnGJNwWWgpCk+iUfyqBF83Bpie99dLNwSkkO7NYGdABv0JXE/N4Bd1ADuuYoghxb/YIM1pMn81kJM5q70sDN2aiJaIX8pi+wk8dAaK+uJYIbh8srkp6sAsIEUuE89cZS1w0CPk+EXpmSvNvHh5bTErYVIPRNpc7GAhdODq0mPZ8hg6gHYYArw0dD9GAtsK+wM8ne37d0+Q4poe+XgLGppY/eAr9djsCCmdgJqhx/S8xip7o2a0GNeLSN9OR/+CWZyykgAGtlxHIjvwQGRnnbHd4dA0Ca7EdcVUcpsPWlrte03CiUtTIYtqvZ2Ard2REkvlBYxZiiVSrlr87YewSpa0XB6LlN+bWqZXcIDIe2e71Tipe8wjvRsu6pqRMDbU90uUg2Gue3OadNtNOKyA7m20McD37+ZCcKtzfLpZHcnm6FrWTmkps6Ptkmj5Ha0SKqCkiKvT5TPMI4vWwp2KV9I5z4BlNfzr7hJ7dWH86+Hq2AYyae98jULpPChIuSkp6qN2usjT7Tm1ibmQsKgo6YWzxOhAfNP7vg7zWwVLOuJU+0AQXLYOKY20nttrrB353GHAeQN+AtMQQJRizfCQFXHfRhbj8l1FMjdAd12WVkJ04TTImujcNRw6yME9YjQlrYO6mNDwDXd+sif9RH1TIHkIsiihxEgyeFn5EROT8gPPX0DHxztnQdAoqeStOmbc5MZWsk+etwbnfVFnf78IByMv5q15v8A/LsDpkefQncAAAxZaUNDUGljYwAAeJyVVwdYU8kWnltSSWiBUKSE3kSRGkBKCC2CgFRBVEISSCgxJgQVOyqr4NpFFMuKroq46OoKyFoQsbso9r5YUFHWxYINlTchAV195XuHb+78OXPmP4WZe2cA0Gnny2R5qC4A+dICeXxECGtsahqL9BAQ4B8FeIGhfIFCxomLiwZQBvp/ypurAFH1l1xVXN+P/1fRF4oUAgCQdIgzhQpBPsRNAODFApm8AABiKNTbTCmQqbAYYgM5DBDiGSqcrcbLVDhTjbf22yTGcyFuAIBM4/Pl2QBot0A9q1CQDXm0H0LsJhVKpADoGEAcKBDzhRAnQjw0P3+SCs+B2BHayyDeATE78yvO7H/wZw7y8/nZg1idV7+QQyUKWR5/2v9Zmv8t+XnKAR/2sNHE8sh4Vf6whtdzJ0WpMA3iLmlmTKyq1hC/kwjVdQcApYqVkUlqe9RMoODC+gEmxG5CfmgUxGYQh0vzYqI1+swsSTgPYrha0KmSAl6iZu5CkSIsQcO5Xj4pPnYAZ8m5HM3cWr6836/KvkWZm8TR8F8Xi3gD/K+LxIkpEFMBwKiFkuQYiLUhNlDkJkSpbTDrIjE3ZsBGroxXxW8LMVskjQhR82PpWfLweI29LF8xkC9WIpbwYjS4okCcGKmuD7ZTwO+P3xjiOpGUkzTAI1KMjR7IRSgKDVPnjrWKpEmafLG7soKQeM3cbllenMYeJ4vyIlR6a4hNFYUJmrn4yAK4ONX8eLSsIC5RHSeekcMfFaeOBy8E0YALQgELKGHLBJNADpC0dtV3wV/qkXDAB3KQDUTAVaMZmJHSPyKFzwRQBP6CSAQUg/NC+kdFoBDqPw1q1U9XkNU/Wtg/Ixc8gjgfRIE8+FvZP0s66C0ZPIQayXfeBTDWPNhUY9/rOFATrdEoB3hZOgOWxDBiKDGSGE50wk3xQNwfj4bPYNjccTbuOxDtF3vCI0Ib4T7hCqGdcGOipFj+TSyjQTvkD9dknPl1xrg95PTCQ/AAyA6ZcSZuClxxT+iHgwdBz15Qy9XErcqd9W/yHMzgq5pr7ChuFJRiRAmmOH47U9tZ22uQRVXRr+ujjjVzsKrcwZFv/XO/qrMQ9lHfWmILsX3YSewodho7iNUDFnYEa8DOYYdUeHANPexfQwPe4vvjyYU8ku/88TU+VZVUuNW4dbp91IyBAtHUAtUG406STZNLssUFLA78CohYPKlg2FCWu5u7GwCqb4r6NfWK2f+tQJhnvuiKXwMQIOzr6zv4RRcN9/RvC+A2f/RF53AYvg6MADhVJlDKC9U6XPUgwLeBDtxRJsAC2ABHmJE78Ab+IBiEgVEgFiSCVDAB1lkM17McTAEzwFxQAsrAMrAarAObwBawA/wC9oJ6cBAcBSfAWXABXAG34PrpAM9AN3gDehEEISF0hIGYIJaIHeKCuCNsJBAJQ6KReCQVyUCyESmiRGYg85AyZAWyDtmMVCO/IgeQo8hppA25gdxDOpGXyAcUQ2moAWqO2qPDUTbKQaPQRHQ8mo1ORovQ+egStAKtQnehdehR9Cx6BW1Hn6E9GMC0MCZmhblibIyLxWJpWBYmx2ZhpVg5VoXVYo3wP30Ja8e6sPc4EWfgLNwVruFIPAkX4JPxWfhifB2+A6/DW/BL+D28G/9MoBPMCC4EPwKPMJaQTZhCKCGUE7YR9hOOw93UQXhDJBKZRAeiD9yNqcQc4nTiYuIG4m5iE7GN+IDYQyKRTEgupABSLIlPKiCVkNaSdpGOkC6SOkjvyFpkS7I7OZycRpaSi8nl5J3kw+SL5MfkXoouxY7iR4mlCCnTKEspWymNlPOUDkovVY/qQA2gJlJzqHOpFdRa6nHqbeorLS0tay1frTFaEq05WhVae7ROad3Tek/TpznTuLR0mpK2hLad1kS7QXtFp9Pt6cH0NHoBfQm9mn6Mfpf+TpuhPUybpy3Unq1dqV2nfVH7uQ5Fx06HozNBp0inXGefznmdLl2Krr0uV5evO0u3UveA7jXdHj2G3gi9WL18vcV6O/VO6z3RJ+nb64fpC/Xn62/RP6b/gIExbBhchoAxj7GVcZzRYUA0cDDgGeQYlBn8YtBq0G2ob+hpmGw41bDS8JBhOxNj2jN5zDzmUuZe5lXmByNzI46RyGiRUa3RRaO3xkOMg41FxqXGu42vGH8wYZmEmeSaLDepN7ljips6m44xnWK60fS4adcQgyH+QwRDSofsHXLTDDVzNos3m262xeycWY+5hXmEucx8rfkx8y4LpkWwRY7FKovDFp2WDMtAS4nlKssjlk9ZhiwOK49VwWphdVuZWUVaKa02W7Va9Vo7WCdZF1vvtr5jQ7Vh22TZrLJptum2tbQdbTvDtsb2ph3Fjm0ntltjd9Lurb2DfYr9D/b19k8cjB14DkUONQ63HemOQY6THascLzsRndhOuU4bnC44o85ezmLnSufzLqiLt4vEZYNL21DCUN+h0qFVQ6+50lw5roWuNa73hjGHRQ8rHlY/7Plw2+Fpw5cPPzn8s5uXW57bVrdbI/RHjBpRPKJxxEt3Z3eBe6X7ZQ+6R7jHbI8GjxeeLp4iz42e170YXqO9fvBq9vrk7eMt96717vSx9cnwWe9zjW3AjmMvZp/yJfiG+M72Pej73s/br8Bvr9/f/q7+uf47/Z+MdBgpGrl15IMA6wB+wOaA9kBWYEbgT4HtQVZB/KCqoPvBNsHC4G3BjzlOnBzOLs7zELcQecj+kLdcP+5MblMoFhoRWhraGqYflhS2LuxuuHV4dnhNeHeEV8T0iKZIQmRU5PLIazxznoBXzese5TNq5qiWKFpUQtS6qPvRztHy6MbR6OhRo1eOvh1jFyONqY8FsbzYlbF34hziJsf9PoY4Jm5M5ZhH8SPiZ8SfTGAkTEzYmfAmMSRxaeKtJMckZVJzsk5yenJ18tuU0JQVKe1jh4+dOfZsqmmqJLUhjZSWnLYtrWdc2LjV4zrSvdJL0q+Odxg/dfzpCaYT8iYcmqgzkT9xXwYhIyVjZ8ZHfiy/it+Tyctcn9kt4ArWCJ4Jg4WrhJ2iANEK0eOsgKwVWU+yA7JXZneKg8Tl4i4JV7JO8iInMmdTztvc2NztuX15KXm788n5GfkHpPrSXGnLJItJUye1yVxkJbL2yX6TV0/ulkfJtykQxXhFQ4EBPLyfUzoqFyjvFQYWVha+m5I8Zd9UvanSqeemOU9bNO1xUXjRz9Px6YLpzTOsZsydcW8mZ+bmWciszFnNs21mz5/dMSdizo651Lm5c/8oditeUfx6Xsq8xvnm8+fMf7AgYkFNiXaJvOTaD/4/bFqIL5QsbF3ksWjtos+lwtIzZW5l5WUfFwsWn/lxxI8VP/YtyVrSutR76cZlxGXSZVeXBy3fsUJvRdGKBytHr6xbxVpVuur16omrT5d7lm9aQ12jXNNeEV3RsNZ27bK1H9eJ112pDKncvd5s/aL1bzcIN1zcGLyxdpP5prJNH36S/HR9c8Tmuir7qvItxC2FWx5tTd568mf2z9XbTLeVbfu0Xbq9fUf8jpZqn+rqnWY7l9agNcqazl3puy78EvpLQ61r7ebdzN1le8Ae5Z6nv2b8enVv1N7mfex9tb/Z/bZ+P2N/aR1SN62uu15c396Q2tB2YNSB5kb/xv2/D/t9+0Grg5WHDA8tPUw9PP9w35GiIz1Nsqauo9lHHzRPbL51bOyxyy1jWlqPRx0/dSL8xLGTnJNHTgWcOnja7/SBM+wz9We9z9ad8zq3/w+vP/a3erfWnfc533DB90Jj28i2wxeDLh69FHrpxGXe5bNXYq60XU26ev1a+rX268LrT27k3Xhxs/Bm7605twm3S+/o3im/a3a36k+nP3e3e7cfuhd679z9hPu3HggePHuoePixY/4j+qPyx5aPq5+4PznYGd554em4px3PZM96u0r+0vtr/XPH57/9Hfz3ue6x3R0v5C/6Xi5+ZfJq+2vP1809cT133+S/6X1b+s7k3Y737PcnP6R8eNw75SPpY8Unp0+Nn6M+3+7L7+uT8eX8/qMABhualQXAy+0A0FMBYFyA54dx6jtfvyDqe2o/Av8Jq++F/eINQC3sVMd1bhMAe2CznwO5gwFQHdUTgwHq4THYNKLI8nBXc9HgjYfwrq/vlTkApEYAPsn7+no39PV9gndU7AYATZPVd02VEOHd4KdgFbpiLJwDvhH1PfSrHL/tgSoCT/Bt/y/dcojlBoQ5UgAAAAZiS0dEACAAqAAxvjeYmQAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB+QGDw0qChFEoKcAACAASURBVHja7Z15eFRVtrfffaoqlYkphEACJCiDzIMEEBmcRSAIjXxOrdcBHK5tt3i/bm37tt3e69Bq+11FG9tuUZwuDi2KLYNoqw2ikUlkiIZJDFMYQoDMSVWd/f1xKjRDKqkkVUmdqvU+Tz1AKlXss8/6nbX23muvrbTWCIIQ3TilC+zFEqVIBoyuoBJAuRTOlHMwa6oM0Aqtlf9Xlf/FSX8GQp/0p/V3pTQobcQlmN7ifLRHoyvB3AdlwGRxELZCiUePXL69biqV29aD4Tj5x/HAMGAQMADoC3Tx/zwecPtfLv/LCRgN/Fcm4AU8/le1/1Xlfx0A8oE8YDOwwf9z/6d9JPQZztA3P5CbJkIXApF3+79Rsv4zMIxa5+sGzgF6+8U8EOjvF7UjQprt84v/O2CL/yGwHdhqPSQ0mCZth1/EgL++LjdZhB57rOqhMFLSUYYDlOEGkoA+wAzgKqCHzS/xR2Ah8C6wDShHm9Xa9GEWFzL2R7E5EXq0huHXTKFy57egDPwh9a3ATL/XTgTiovTSa4AKv7d/CXgZ8KBNEnoOZejbH4pxiNDty/d3z+JY7ke142s3MAmYBozyh+WxzFZgNbAIWApUY3ppf95E+s2dJ8YjQo9sNt04g/LvV4NSgOoMDAbuBSZK79TLMuBpYBNaHwRNUv9RDH7tXekZEXpkkTu8W633vh54HMggcibO7IIP2A/8GliA6WP0+r3SKyL0ViRvE7k35+CfJf8JcJc/LG8jnRMSSv3h/fPA+2jN6Fc+hIFDpGdE6C3luQ1A9QKuBn4JdJCeCStHgaeAd0DvwDTF04vQQ89zSjE0A5wZmQ6sde15wAjpmVZhLTALVJ53X4FvQyH8QmxYhN4sKsvJHdfPP7nGbP8rSzomIigAngGeQZuMXvk9JCZLr4jQg2f1BUMwK44CKhX4GXCPhOcRHdbPAeaCLjISOzBqxUbpFRF6YFYoRdy5XcFwxAP3Aw9Jr9iKh4AnMH1VNd/s4wKxbRH66eQO74ZyuNDafBq4E2uDiGA/qoAXlGHcq701jF6/T3ok1oX+7XVTqdz+DVbSOQ/6w/RUMYuooMgK53kYbfoSep8b07vrYlboX52bgXLEOUBfDLwHyExOdFIGTEepz7S3xnf+N/tjshOMWLvg/Hvu4CsrTB8AOg9YLiKPapKB5WidpxyuAV8N70b+L+4Qjx7V4/DsTFDKDbwKXCMaiEneBm5Cm9Wj1+0RoUdVmD6sM8rhBqVuxlqKaSv2HtOUAPegzVe0r4bzNxyU0N3W7NjK+oljUM74VJRaC8wXkQt+G5iPMtYqZ3zq+kljYcdW8eh2ZGWcwjUkE+ABrBn1BLFvoQ4qgYeBP3i+3c14jxah24G8226k5NsVgOoJvAhcJLYsBMHnwG3AzvbDL6TfC6+K0COVJUqRMiLLQOscQEqSCk1QhJqqfb7FR7/Za0ZTSeuoEfoXmQpn50ywShNJRRehOSwDJnkP7GbcHi1CjxRyR2QCKht4C+gpdiqEgJ3AtaDXjV672/YXY+tZ91V9FLnZ3QE1E2ufsohcCBU9LZtSMz9Riq8G2nuByrYefd3k8XgOFTixikDcJHYphJFXgVmutCxv9pKV4tFbhF07+PIChedQQRqwRkQutAA3AWs8hwrSOPAp7N0lHj3sXvzgLjAcfdH6SyBFbFBoQYqV0zVGe6rzXWlnkb3UPt7dPh591QpL5MqYjNabReRCK5CivZ7NKGOy59AuWLVChB5Sli8h995/A2Xcj3W6hxz3LLQWTmARyrg/995/g48WS+geCr4eOwhdXQJWIcB7xM6ECGIO6NlmeQ1jvjsgHr3J0XpvRULXTgrrYD4RuRBp3APq5bNuvF6tnzREhN4U8n9xO472mVT8sPM94BaxKSFCuaXgvYXvZS/bxPb/uEtC98bw1bDOKGe8G6vE0ySxJcEGLHV16Djdc6yoevSa3SL0IEXeBngXuFzsR7ARH5f5fDOqqspKp3x3TEL3+sJ1vycXkQu2QgGlXt/l1T7zXeVKdH999+3i0eti1VkKR2p3QC2RcF2wocipNs0TYfw3mwonD8uAKfu0CL2W1eOGEJeSqKr2738PmCamI9hN5FWmaR2g/S8WJad2ml5RhZ70ZesfEdX6ofvyJZhVx6jav/8lEblgN0r8nlyd+da0sqLDL5llhyld1vpJNa3r0VetsDLeJBlGsH+4Hog5wOwr/rQA57gLY0/o1gaVH0Gp+4HHxXSEKAjXA/FrtPlEXHovLl++KoZC9107/BtU1GTgETEdIUrC9UA8gjIm1xTugB92xI5H/5tSdMvO7AtsRjaoCDby5CVeHzUNh+t14QU1qMOm/fljWkFzLS50f2WYNOB7ZKupEH1j8vooBvrFdTn7UEuH8C0auq/qo2rLP30kIhfsRO2YvJmkAB/VHPjB+UE3Fb1Cd7TtBlaNt2FiOoLdPHmIpDkMmOdI6RydQs8dkQXKmInUeBNsJvKa5nvy07kJZcxcPCQ9uoT+RZYCyPZ7c0GwjcirQi/yWuaByl7UUUWH0JcohTMtE6zDFQTBFpSENlwPxFvObunMV8reQs+7/UbrLDTrmCQ5XEGwhScvC0+4Xhc9gaWdhmQYq2beYF+hl2xYgf/AQzkLTZBwvW4monXOsXWf2lPoK+MU/qOL5VRTQcL1+vkAVM/3whjCh0fo2/NxDckE63xyQbCFJ69pWU9+Oi/GDU6H7VvtI/T1d98C8ABwkZiRICIPiouABz6+Izxj9ZCnwPprvqUCu4EEMSUhkilr3C60cFMJZGpPRVGoa86F3KMrhxusg+RF5ELEe/LqyBE5fs0sU87QSyekQs/NzgSlbsZKjhEECdcbTzZK3bx4cHpkCn3rPXeCUm6sihqCENEir4pMkdcyB6XcX//8jsgTevGXS8A6ML6tmJMQqZREXrheF22BVw+vCN3KdEgm4746NwPlcA0AtogpCZE+JrcRA7WvJm/KlqLW9+jfXjcV5YhzAAvFnAQJ10PKQuVwOz6/+srWF3rl9m8AfTHQR0xKkHA9pPQBfXF5/poIGKMrw4F1GKISkxIi0ZPX2M+Tn3wJ7/k11npCzx3eDeBBIFnMSqgX04dZvBuUEpE3jmTgwcWDOreO0FcohXI4AX4mViw0hDOjJ72eexcqWuZIYZuOyQPxM+VwsbAZD8kmCz1ueDe01k8DqWLGQkNobw2dLpnMOS+vxCwKn9gjNOOtuaRqbT7tHtipZYW++oLBoIx44E4xYaExpIwcy4AP1qFL9oQ8jI+icL0u7sRwxi8dM7DlhG5WHAe4H4gX0xUaS/vBw+kz72MoLwiZ2G28hBYs8cD9ZtmRFhJ6ZTn+cP0hMVmhybHouEvp/eePMUtCE8aXRF+4XhcPgUqlsiL8Qs8d1w9kAk4IhdjHX0b/t9ZgHm262Fu4xlsk8LPFo3qGV+jPKVUbaskRx0JI6DA0m75v/NOajW9kGB8D4Xpd3INS/LKRfdUooQ/NAGA20EFMVAgVHc+7gF7PLkaXNc6zx0i4fsazEZg9ppGZK40SujMj0+EXuiCElE6XTKbva19aSTVBevKa2PLkJzPbdXa6IyxC92fBDQCyxCyFcJCSPZp+b3+FLt8bMIwXkYNfgwMWD0oLg0c3DJAjlYQWEHuvOYvQpQV1vh+DY/JAzKMRKfDBCT1vM6B6ASOkf4Vwk3bZFPrM+wzz+L4zPHkMjskDMQJUL/I2BfXLQRWeyB2RCajfAI9G4hW3u3wa7k51pweWbd1KxbqVjftCpTCLCjB3QZsZI0gYPB5nm3bUHNxLxT//SvnX4ByUinInNrKlmpQrr8PZpk2d7x5fv47q/A11vudbt5uuz/0B0+s9s7kOBwee/z0q+cw6Y7rqGF1m3Udd91kpxYGX56DiEoHT3jd9pF5zK0ZcXEjukeGOp8dt96CcrqA/U/zNGvJvuAAjuTOlHq/dika0BP8J+rGcjYWhEnoWQDGRONvu9TB06VoS0rvW+fbe5cvY89vgM3XNPbtpN+v/0mXCBFLHXVa36MpLOfDJUg4smEf1xk9RbbsH/QA5d/k3uDuk1Pn27rdfZ+8TD6AcZ4ZkHaf/lD4PPBbwq79QCmd25pnXs243Y+q5xz88/XsOzJ+Lcied+oanhJGrD+Bwu1v19h76dCkbb59MdXK6yPpMjgIpORv3h2yM/hMidUlNgen1BPahPm/Q3tZITGDQZxsY+MhTAUUO4EhqQ9dp1zD8nU/o+sCzjVr/1V5vPW31BX4Aeb1h6T6rParOjq2vX1ssjL9kEn1fWIxZWiiyPpMOfm02X+i52d0B7orq7lKK+J69yV6+gbb9hzbqo1k3383QD3OhsuX2Wsca3S+bzKh3vsY8LmKvg7sWD+7SPKFvuvEqUAbAqKjtJq1xucsZ/NIHOOKbVjg/oXM6A9/7Dr22QMwuTHTOHsXw1/6BPlYoD9RTGYUyWHH99KYLvfz7NQDXA22i1pk7FOd+ug9HUvOK5LTp048eSxeBTBiFja7jL2Hw8wvRJfulM04yPeD60i1fNSN0t56cj0etM6+pIvWqG0M2s5wxcSr6m71iemEka/J0shesxFciYfxJPN5QlBNQ6N/ffRugOgMZUevN9x6i572/C+l3Dtj0DdSUiemFkfTzxjFywUp0qYTxtT4GVOev7prVeKEfy10GMBhwRGvvtL/nfpSrfm++689/5AulWKkUuUpxZPWqen8/uVdfjJQMMb1wi330OAbP+Ru6WMJ4v0YHF3/xYRNCdyu97t6o7RrTpN2ocfX+yrfXXMSBeXNwZmfiys6E7Ey23noFe995JXCPx7txZvUX02uJMH7KDIa99jFm2SHpDLi3vpTY+sbobmBi1I7PK4/hbht4Aq5s104qtm3j9M5TiR0pfO2v6ECTbsrAndZRJuVaiG4XXsbIN7/ArDhMjB8tMNGv2eCF/u3VkwEmRXOv6OoynAmBl9O8Hi/K6az7vR9yoZ5sM1fbZLTpFRW2EF1Gjmbos++ii/bHutgnffZ/coIXeuUPmwGmRXWXaGpzBJr22XpQSjX4O0JoyZw4lcEvvu/37DHLtIqt6xsRulszmaPEfARbjdknTWPEG//ErDgaq10wKtAqxBlCX3WWAnAB54jpCHYjfdT5DPvLInRxYSyG8ecArkWdVMNCN1LSAW4VkxHsSveLJzDg2bdiNYPuVkfnjg0LXSknwEwxF8HOnP2Tazj39c8xK0pi7dJnKsMZxBhdKTfQW0xFsDtdx17I8PmLrQy62Anje6MMd71Cz7vtRoAkIFHMRIgWsfd/aoF/6S0mSASSVs28IbDQSzZ8DtAHiBMTEaKFntOvY8irSzGrYmIPQhzQ59iaT+oJ3a115RliGkK0kXnpRLJfWYquOh4LlzvDX7U50BhdAVwlZiFEIxmjxzLgj6+iD0T9FterTp+TOH0yzg30EJMQopWzr5zBgBf/Fu2evQen5b2fLnRJkhFiQuzDX/kIs7oymi/znDqF/u01OSDLakLMhPHjGPLsG+jDURvG9/7s6ivPFHrlzo1gna0mCDFB1uWT6ffM6+joLEs1oCJ/dR2huzXjPlBuvxBL9Lr6Boa+8ilmTU20XdpAlCPgGF1KowgxR/cLLmbYC2/7M+iihv51jtH99JXbLsSm2C+h7x9eQx+KGrH3PUPoS6w9rPFEcSFIQWiI3tfcyKD5H6I9URHGO4D4+f796QaAv3LaMLnVQqzT44oczn3xPXR1eTRczrC2J3t0oxsAg+Q2hwipNW5ruo4ZT7/H/oq51/Zh/CBH25OEruKBWFtaM8Cs5/TSenXsrn+EY3q8Inab02v6NfR78U27e/YBKvkUobc9Y/Ae9U43oSPessC7mdzJiZjlxXV667ih01FGYCFXFx9HOZyiFruP2adfy7CXPqz3qOsIp6/fiVtCdySnAXSJKaG7k6g8Uhzw/YSM7vSc8zbmjt0nSjtrrxcKCzjnd48ErCCrvV48hfvFo0cJ3caMZ+BTL2HacyNMF2eHHv8SuvZ5DKxZ9xhSOhxd8mb9vXTZJAZ8+hVJYy7HPfxiUq68muwtR0g6u0/Az/g8NXh3bxGFRBFnTZxCn6fn2zGDLt701hgAVnyptYo5oQNlr7xP5e92kpDZM+DvtD93NO3PHR30d+59dS66xgMOl52fgZR4PVKa/uQY+PqbSUzvxsaf34ByGLYRul/bJxJmFPUc5xKtGEO7s+2xB0N2fJK35Bh7//0+24u81OujxucRdZ9G5kWXMuS5N+zk2d3+W3pKZlzMCR2lqMhdwvHt34Xk63b86SkcI7Js3SWlXh9Vcm5cvWLv/cjLmIWFdhE6p3t0V0zeubj25F01mrId+c36mh/nP0/xWy/UeyabHTx5tWki04gNhPE/vYWB8xehfRH/QHSd7tFjV+hYS21brurHkTWrmvBpza75f2b/U3ej3El2DWyscF08edCcPXkqQ//8FtpTaROh+06sEcbwwq9Gu7PI/8k4fpj7JDVHjwT1qcrCfXx77YUUPvcYKrG7fcN1j0fC9SbQfdyF9HloLuaPERvGn9C0oa3sMEX9Z6VHNqaJDvgKMpTWGiMjk4OvzGXteZ35bvZPKS/Y6f8OH9pnvQCKVn7M+gl92DAxm8qdPzZqFlbX21azvg8G/HxT/1+AKp9Jtc8n4XoTOefq6znnxTci1bMbtR5d+SrKWD2+vxuosmtnOzqkYrjrXh30lZVgljXhWB6fF126HyM5DkfngXi2foOzR198hflow4lKTG9SUowztTPKWfcoyXusGF1VUbdQq0uJO6s/1PXgUgrPvgJOL/Fb+4BwZWSecYyzUlDq05QWbEfVtUpQU8zl64qIS0oWNQfB7i/+yca7rqs3Y7KViM/5Zne18paVsubCAbYWutDIMTn/ml0PaJYi9Eazc/EH5N0yDSMjPaKEPnntrmrDrrPEQtMpCWp2XaFNjdbyCvZ1ds5Uej71IromskpJa9NEdl7EmCcvCXJ2XcUlc/jwYZzl9t6XrVp4z0H6lOnsvPk21OB2EdUPTtl8EVvhevBLaOqEp7IzLdl+Q2tWX3sFxtDuYEbOjjelFM4InDywg/VgdEoPcBKvwiw6eGKWPCLampZBhc/EZ+pTQzgF3v0FIFtqm4+nhq+zeuAY0jVy7n3tbXY6cWLEQJk4nwddcwxqKq3ZZweouBSISwy43bReqvbQ/S+rwOGo8+l58LlHqfzofXA2IQfJ5/W3teKEGJW7A8QlNamt+oc9ZH64us5lOGUY/Dj3MYoWvo6Kk5OymxwWG4Yl8sHpESdyABxOnIZlrBowsfNaeh3iNiikw0MLcXfrjrN9BxzJbUAZ6JoavCXH8JWVUfLRQsr++EdU3x6Nu0mGgaprOUupxi+7eapQ1YdIeeoD3OnpONu1x9GmHSiF9tS2tZySf/yd0gcexRgRXFsVUHKMutvpF3qTHnTCKSJff+M01JBuoH2R1jzTr22Mk7yONyp6XikUlbS547dkLT9Em5FjiEvvhpGQhPaZVvEIw8DZPgV3t0zS7ryP7l+sI27UJejju1t+5OzdQ9tfPMxZXxTRZvhIq62JyVaCjtcLysDZLgV31+6kzZxN5paNxI28CH1kd1Bj8ipZVAlvuN6lC95DeyNR5KdounZwpgEP1iHq9qa8gIw31uDq0i2oEkDa68GZlkHX3z3OkYEDKJn3NLRUnlh1KV1fXYOrS1fMIEoMa68HZ0onuv7+CY6NGMXRPz0asK21s+syAxMeDK1PCtd9Efso+pdHP1XotvbkuuII3d7ZhCu98Xnn2ushZep1tL/7N+ji3WFvK644ur21Ald6tya01Uu7CVPp+Jsn0WW7z/DkZbJBJay4nA6++elka+ItwmOO04UOUG3r3j9WQPqLS3B2TGv6VlGt6TDpKhKv+Tno8PlCvb+ALk/+FWdKarPa2mb0RSRceRf4c/BPzngTwvSM9npZfWlffMeORObE22kx44kI5CSPbl+ha03y7DnEn9Wn2Z2vvV4y7n8Ec31BuBpL0t2/I753/+bvXdcmXX/zGHrLvhPhuuwnD7PIMzPRxEfUOnkDQj/JoyulsXGuu7l+Dx0uu7zhG+V0ohxOVANLir7KCjr/4+PwtHXbHjpMyGmwfFXQba2opOM778p+8hYI19fnDLHG5PahCpQG/2SccrhM7a2xrdDj75iBKyUNs6Y6oMcv+XIFpR+8jkpqg6NjF9pNmUFCr751T9hpjatjCnhrwBna+Un3pSNxZ/XErK4O6KWPf/E5ZUvfBsOBo0sW7SZNJbHvoACTi5q4zO5UHdqHkZouigwDhtasvXoC2ki2iyc/IXTldJknhO4rL8Jwtz0ADLbjjWg77eaAs9bK4eDA0/9N5fL3T8kAK//Ds6R//jEJ59R9JHxcWheoPgDOzJCG7W1+OhvtqdtYlMvFob88TfnCV08k43i2bKDi2WdJX7ychL6DoY7arEk9eqH2A6kiypATwRlvQXDAd7zgX2N0XXUMIN+WN0JrnB06BBzvlm9aR8X7fz4jzdPIzuTIX/6IcjoDiC4OZ5/skNeAi+/VH23WvRxTsWkdZS88dkbGndE/k6InZmPEuQIEASZtrr/MjoYY0TgNg3WRnPHWMPnaXw/DErqVbZlnT6Gb9R5/VHOoCJVc9zKI561PAmexaY2z29khKwXtnwsJmKUGULl9G6pTRt1tXf59wLZqrYnL7I1sOQ6tyE9kvNmXPF12ktBNa9J2s109en3TzNqk3pTUemeoHa46Q+VmKL3+t02zySmpyuUSdYYyXI/sjLdg2ewrOUnoftFviMqbJmtNQiMwtGZNVg9UZGe8BcuG2iJqBsBka/xRBfjkVguxio0y3oLBB1Td4h/OGae5vXy53ZEZlJRIcBLePrZXxlswnKLl0weE38ktjzxKvD6p3Blukdsr4y0Yvqtb6NZTTM77jTBPXiq70MIertsw4y0YtpwcmZwQesJZg8CuS2xRLnIhPJyS8RZ95CX2yT5T6EP/thRgu9z+yEB2oYUZTw1fd+2K7+jhaArXT2b7xe8uDjhG3yoWEBkil11o4SMKMt6CYWvdY3SLauBHMYXWC9fLvF4J18Ms8ijIeGuIHzlt23ldaVgLxRxahwrTOvRQCGO4Hh0Zbw2x8PSMzlOFboUx74pFtA4mslYeLqIs460h3j19j8YpQm879AKAbUCNmIYQLURZxltD1ADb2o+4NLDQB8x7A6AcqBDzEKKBKMx4a3AECJSPffl/qX+MrnU1sswmRIvIoy/jrSG2+zXckNB9AC+JmQh2D9ejNOOtIV7S5pmV288Quq94P8DLYiqCXYnyjLeGeNl36EjDQh+7S4NV+F2SZwT7Ef0Zb/WxFfBMO6QbFrp/nA6wWqwmhONFrIw3WSUPHzGS8VYfqwOVE6tT6AlnDQRYJKYTWpFLxlt4RR4DGW8NsSix97Dghe7f4LLUNpen6xdZfe/XWxHO5w2ZyIPZoKIMA93UAo9eT+yad+xkvDXE0osXLg1e6H6qgWURf2mGgfYFvrlxnVLQ5YV1vueacUHgyqlK4du/Cxo4KaUhTjkmSZuYZmAht+3ZE33wcJ3vJYztFvAhoFBU79nZ+HPZo4AYy3irj2XUc6xaYKFbY5ynIz8uNvCVHAto5ElDR5Iw4fozyjab63bT4fZfBTxaWXs8ePLXNFk8SqkzTzXVULEzP2DJ5/bnnkfK7T8/o62+/EKyHvwLpqdur60cBmXvLm9yBVm7EmMZbw3xdH0PuoCW0X7kZQCbsEHByNIPXg9Y7lj7fHT51aO0/9XjOLp1xdmzD+4xl5K+4h8kDx0V8DtrDh8Ad+cmihxKPd4zw3WlOPS/f8II0FbTU8PZd/2Krg88iTvrbNxZZ5E8fgJ9lyylw7CRgQ+pKPgBs32MzXvEXsZbvYNMYFPK2CmB5zACvdHv+ZfJHZF1ENgPdI/kqyyf+ybmf/w3KiEpYHjf/oKL6XCJ/yBGrdE+HzrQuFYpPEVHwOluUnsqfVBl+uo8ILF04RdUPvgjcWnpAbyzky4XXUb6ZRNRWIczaJ8PM+AYXFFaUICRlh5bIs/MtGbXY28JrS72AwfPf35e4z36SeH7ryP9Kh3Du1G8vOG5Q+31Wi9f/UGKIyGRg5de3uT21Gd6jkFdOPJ9flBtNYNoqzMxgd0/mRFT4XqMZrzVx68bimrqFXpS3xEAC4DSSB+nlz57D9V7fmj2hJRyOCn8f/+FMTwzTG1V7Lvup1Ts2t78yTOl2PrEQ+j+HWPCmmM84y3gyBVYkDxgdNOFPviN9+yTPNMmi/23XorveHHTBaQUJSs+ovzV/wnrxnA1JIP82bfiOVbcrMm+49+u4+iCZ1AhPto5IontjLf6WI3WXPjm+00XOsDodbsBno/4y9UalZDGnmsG4y062HjhOJ0c/3QJR578LSotM+xt1dUVbLxyKNWHDjQh6nBweNWn7LjvNlS76A9hJeOtXp7P2VTYcDQU5Je9Dxy1xWXHdWPf7VM58uEi60jkBjymcjrxHS+m8H8epvjBWY14MLhQThdGHS9lGEGdzagSO5F3wxgOff4xhisuuLZWlPP9I79l1503BB0NGIHa6XRhOB0BZ/OVoawlu5C8VJNFLhlvATnq12bDthZMJlbuiExA/QZ41DZd4K3GaFdDyv2v4s7oirNDR4yExH+9fawYb8lxSlf9g9L7/hM1KDP4cN1bTdK0G6hG4dH61I8pRfHypejy4J+LuvwQrnY+uj+6mMQu6cR1SMGZmOR3/hrP8aPUHD9Oce4K9v/iPhxDu4EZ3Kqnri4h9bp/r1vMyqDorRdRcYmc8WTyVpH1+z/hiI8Pzfja5aLdkOGNE7ynhnVZPSyRazkWsA7+E/RjORsLQyN0Nq4nd9b0Xti1IIW3Bl11CBVvov1HSSp3G4hrB0bTkkzClbuuPVVQeRTDDdoLuhqIN1Dxqc3O0mvVE4CNvgAACnFJREFUQKv3UAbNeTHo/ja05uuuXWV2vX565yxYvoMBgxqOjIL6uiHDAXYAa4ER9hvkxaGSrdBPNXPCNtwbVJQrHlzpln91g0qKPet1OR2svXqClfEmY/JArAWCEnljxui1oeKsWO7ZxmxQEZrYx5LxFiyzgh2+NUroo9fvBetstoJY7dkSOUEl/CKPvRpvTaEAyMvZfDD0QgfwHt7tA56JVU8u+8nDG65LxlvQPOP9sbBRs5ONEvq3li9/BrsstYnIbYFkvDWKo8Azq0oa2ceN+eWfa127TDMnVnpVxuRhRjLeGssctOapRhYoafTa0ugvvgeYGyueXMbk4UMy3prE3JzVOxofNTX6E9ZW0CLgIQnXheaIXDLeGs1DQBEJSS0gdMBIaAvwBFAVrSKXcD3M4brUeGssVcATRmLTKow0SeijVm4GbVYBL0Rbb8oSWniRGm9N5gW0WTUp97uWEzpAzfq9KKXu9YfxUeHJyyRcD6PCHVLjrekUKaXurd58sOnd39QPXqA12srMmRsNIpdwPbzU5H3Jl13SJeOtaczVpo+rmloKnGA3tdRD7ogsB3AMsO0iqEy8CRFMGdA+Z+P+Zo1zml8fWGsfMJ2gdmBHpicXkQsRigam14bOrSr0hD7nAnwGbBORC0JI2QZ8ltRvVPPtvbmhO8BXwzNQhmsAsMU28ZB/TC6z60IEM1D7PHlTthxu9heF5GiP89fvB63zgLft4sllCU2IcN5G65CIPGRCB+gwegLATUBJpItcwnUhwikBbkq94MrQ2X4oQvdacrMzQambgfmRKnIJ1wUbcAtavxJMdddWETpA7ogssMrcZEdSz4knF2zCOmBEzsb9If3SkB+/qb3VABOBykjx5JLxJtiESmCi9oZ+C0nIhX7+hgO42nUqAh6OpHBdEGzAw3HtOxdNySsOvRZCHboDsD2f3OsngLW+fpGE64LQIJ8DF+f87VPo088mQgdWJipcAzJ7YpWJbnFPXiIiF+xFr5pNhTunh0mPRrhaPb5CA3onMLU1wnURuWAjpoIOm8jDKnSAtsMuBFgMLGvJcF3G5IKNWAZqcfsRl4bXAWod3r0oS5QiJTsTfwjfU8J1QTjBTqDX4U2F3BJmHRrhvpLJWuMt2g1wrYTrgnAK13oPhF/kLSJ0gHG7NFiJALPCJXIJ1wWbMQtYN+1gy+zuDnvofjL+FNlXsHLiQzYmF08u2IxXgZtDnf3W6h69Fl/Jnton2YZQeHLJeBNsyAZglu9IYYv+py0q9LHbNK6OXb3AFUBxc0Qu4bpgQ4qBK+I6ZXqn7m3ZgkwtGrrX8p5SpGdn9gU2E+wZ7RKuC/bGCwzau6kw/85W0JzRGlc8/YftoM18YJq/AxrlyUXkgg1FPg1t5t+5c3urNKBVhM5ZvXClnQVaLwF+KyIXopzfovWSuPRecHavVmlAq4TuJ/hyJbmzbwTrKOZ76vtVqfEm2JQ5wOwr/rQA57gLW60RRqt2wZjxjH70zwCzCVCVRmq8CTZmPjD7wifntarIW1/oAJdPwtE2FVAzgUUSrgtRwiJgprNdGskTJrV6Y1o3dD+JVVkKR1p3QC0BJkmNN8HGLAUme/cUMq04MvRlRErPjC3QdBg9EaxTXz6WU00Fm/IxML3juJyIEXlEefRavhrWhXLlalPt870LXC52I9hM5DO0p6J0ynfHIqphESd0gA8HdEA5E9zAe8AksR/BJuH6dO2pqI40kUdU6H4yU/KOkjo+pxqYzGkTdIIQgSwCJncclxORIo9Yj36i91IUzu7pCngJuEXsSYhA5gMzvXsKdSSNyW3h0WuZVqxxtEvTwK1YiQeCEEnMAW51tkuLaJFHvEevpWz5Uv553yyA+4FHaMJGGEEIIV6s1O0nLnxyXkSsk0eF0AG8X67ko7uuAVTtuF3ELrSWyKeh9ZIr5r6Fc9wFtmi0YZfedY4ZT1zns0GbS4BBNGM/uyA0kWJgENpcEpfe0zYit5VHP8EPO/hrz95kDE5PAz4Chon9CS3ABuCKfZsKD92xc3ur7UKLeo9+grN7cbvWuFLSDwEjsepvCUI4eRUY6UrtfugOrW0ncnt69JP4oLvCkZIOMBOYJ/YohIFZwEu+I4W0dPknEfppLB6SAdZ57G8RxkMihJhiJ9ZZBOtaslqrCL0BFnVRODung5WKOFHsVGgGy4BJ3gOFtFTddRF6I3hFKVIHpxtADvCB2KvQBKYCiw9vKjRviSJtGNF0h27WmvYjLjGBvwO9sM6cFoRg+NyyGf339iMuiSqRR51HP5n3lCJucDrAA8CDQILYslAHlcDDwB9qNhUyPUr1ELVCB2BbPstvno6n/Fiqf9yVLXYtnMQ6YKKrXVrRhBffhHP6Re2FRrfQ/Xw4oCPK6Qa4GWsjQlux8ZimBKvq8CvaW8WUvOhPsowJodeyeHA6KOXGSoC4Ruw9JnkbuAmtq3M2FcbMRRuxdIdzNhXScfSEaqz10YHAVkCL7Uc92n+vBwLXpo6dFFMijzmPfko4P7ATyuFyABdjlaxKFj1EJWVYBUc/0z6Pb8qWwzHZCUas3v0pWw6T1Ge4D60/AdoD/wUUiS6ihiL/PW2P1p8k9R0RsyKPaY9e1/hdKYWGp4E7gXjpFVtSBbyglLpXmz5yNh2QHhGhn8pCpXAP7gKoeKxqNg9Jr9iKh4An0LqqevMBrhLbFqHXx9Lz+mJWlgCkAj/DWorpID0TkRzFWjKdCxQZCe2Y9PX30isi9EZQWc7i83phnQLHbP8rSzomIijAOoX3GdDkfL0DEpKkV0ToTeeXSjE2C5zt0h3AAKy97yOkZ1qFtVh7xPO8hwp9qw7AU2LDIvRQs3hQZzAcYG2auRr4pYT1LRKePwW8A+zA9JGz+aD0igi9BVjxKYt/cUNtWP8T4C5gFNBGOicklAKrgeeB90GT8/IiGD5KekaE3kocL2bx+IG1/7oeeBzIABzSOY3CB+wHfg0sAIiG6i6RgCFdEALapZCzcT/JfbNBmwuATKAr1mmwy6SDGmSZv6+6Aploc0Fy3xEicvHokc+XM2/g6Np/gDIA3Finwk7zh/fnxHj3bPWH5YuwSn9Vo01SRl3O+S++JsYjQrcvn155KZUFebVjehfWeXIzgd5AIhAXpZdeA1QA27EOy3wZ8IAmocdALvngEzEOEXoUYposSnfg6JSKcrhqvX0S0AeYAVwF9LD5Vf4ILATeBbYB5aCrtc+L73AR0w6YoJTYggg9tvjihhkc37TKb/yqVvzn+L39AKztlf2BvkTOBJ8PyAe+A7YAeX6vvRWoBg1a027oeMa99o7cZBG6EDDcnziOyn07Tvd+8VjHUA3yPwT6Al38P4/3PyTc/uGBC+swyoYmXU2swwM9/le1/1Xlfx3wizoP2Ix1PFHViU9rTUL3PlyyZIXcNBG60Gy0yXzDQVvA0QZUGih3RxyueLQ2DX84UPtUOP3v9X7zSX+e8nelDNPnqURXFqOLwFdq1WG6xfTVTjQKInSh1Z4JXg++igpMTw2m14v2+dBaoxzWadPa50UZBsowMJxOjDg3joQElNMlnReF/H9j9/zNgaZunAAAAABJRU5ErkJggg==
+      mediatype: image/png
+  links:
+    - name: Website
+      url: https://red.ht/mta
+    - name: GitHub
+      url: https://github.com/windup/windup-operator
+    - name: Documentation
+      url: https://access.redhat.com/documentation/en-us/migration_toolkit_for_applications
+  customresourcedefinitions:
+    owned:
+      - description: >
+          Create an MTA Web Console application.  
+          
+
+          To access the MTA Web Console application from the "Developer" perspective, please go to Topology and click on the "Open URL" icon on the web-console pod.  
+          
+
+          Alternatively from the "Administrator" perspective, please go to Networking->Routes and click on the Location hyperlink.  
+          
+
+          In order to connect with default login credentials, please use "mta" as username and "password" as password.  
+          
+
+          Known issue  
+
+          If you want to customize the MTA Web Console instance's parameters and you can not see any in the `Form view`, please switch to the `YAML view` and change them as needed.
+        displayName: Migration Toolkit for Applications
+        kind: Windup
+        name: windups.windup.jboss.org
+        version: v1
+  displayName: Migration Toolkit for Applications Operator
+  provider:
+    name: Red Hat
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+              - config.openshift.io
+              resources:
+                - ingresses
+              verbs:
+                - get
+                - list
+          serviceAccountName: windup-operator
+      permissions:
+        - rules:
+            - apiGroups:
+                - apps
+                - extensions
+              resources:
+                - deployments
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+                - persistentvolumeclaims
+                - services
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - ingresses
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - routes
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - windup.jboss.org
+              resources:
+                - windups
+                - windups/status
+              verbs:
+                - create
+                - list
+                - watch
+                - get
+                - update
+                - delete
+                - patch
+          serviceAccountName: windup-operator
+      deployments:
+        - name: windup-operator.0.0.5
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: windup-operator
+            template:
+              metadata:
+                labels:
+                  name: windup-operator
+              spec:
+                serviceAccountName: windup-operator
+                containers:
+                  - name: windup-operator
+                    image: quay.io/windupeng/windup-operator-native:0.0.5
+                    imagePullPolicy: Always
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                        resources:
+                          limits:
+                            cpu: 1
+                            memory: 200Mi
+                          requests:
+                            cpu: 100m
+                            memory: 50Mi
+            strategy:
+              type: Recreate
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+  keywords:
+    - monitoring
+    - security
+    - alerting
+    - metric
+    - troubleshooting
+    - run-time
+    - migration
+    - modernization
+  replaces:  windup-operator.0.0.4

--- a/src/main/resources/operatorhub/mta-operator/0.0.5/manifests/windup-operator.v0.0.5.clusterserviceversion.yaml
+++ b/src/main/resources/operatorhub/mta-operator/0.0.5/manifests/windup-operator.v0.0.5.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
            "mta_Volume_Capacity": "20G",
            "docker_images_repository": "quay.io",
            "docker_images_user": "windupeng",
-           "docker_images_tag": "5.1.3.Final",
+           "docker_images_tag": "5.1.4.Final",
            "docker_image_web": "windup-web-openshift",
            "docker_image_executor": "windup-web-openshift-messaging-executor",
            "messaging_serializer": "http.post.serializer",

--- a/src/main/resources/operatorhub/mta-operator/0.0.5/manifests/windup.crd.yaml
+++ b/src/main/resources/operatorhub/mta-operator/0.0.5/manifests/windup.crd.yaml
@@ -1,0 +1,282 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: windups.windup.jboss.org
+  labels:
+    application: windup
+spec:
+  group: windup.jboss.org
+  scope: Namespaced
+  preserveUnknownFields: false
+  names:
+    plural: windups
+    singular: windup
+    kind: Windup
+    shortNames:
+    - w
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                hostname_http:
+                  type: string
+                  default: ""
+                volumeCapacity:
+                  type: string
+                  default: "20G"
+                mta_Volume_Capacity:
+                  type: string
+                  default: "20G"
+                docker_images_repository:
+                  type: string
+                  default: "quay.io"
+                docker_images_user:
+                  type: string
+                  default: "windupeng"
+                docker_images_tag:
+                  type: string
+                  default: "5.1.4.Final"
+                docker_image_web:
+                  type: string
+                  default: "windup-web-openshift"
+                docker_image_executor:
+                  type: string
+                  default: "windup-web-openshift-messaging-executor"
+                messaging_serializer:
+                  type: string
+                  default: "http.post.serializer"
+                db_jndi:
+                  type: string
+                  default: "java:jboss/datasources/WindupServicesDS"
+                db_username:
+                  type: string
+                  description: leave empty for auto-generation
+                db_password:
+                  description: leave empty for auto-generation
+                  type: string
+                db_min_pool_size:
+                  type: string
+                db_max_pool_size:
+                  type: string
+                db_tx_isolation:
+                  type: string
+                mq_cluster_password:
+                  type: string
+                  description: leave empty for auto-generation
+                mq_queues:
+                  type: string
+                  default: ""
+                mq_topics:
+                  type: string
+                  default: ""
+                jgroups_encrypt_secret:
+                  type: string
+                  default: "eap-app-secret"
+                jgroups_encrypt_keystore:
+                  type: string
+                  default: "jgroups.jceks"
+                jgroups_encrypt_name:
+                  type: string
+                  default: ""
+                jgroups_encrypt_password:
+                  type: string
+                  default: ""
+                jgroups_cluster_password:
+                  type: string
+                  description: leave empty for auto-generation
+                auto_deploy_exploded:
+                  type: string
+                  default: "false"
+                sso_url:
+                  type: string
+                  default: "/auth"
+                sso_service_url:
+                  type: string
+                  default: "/auth"
+                sso_realm:
+                  type: string
+                  default: "mta"
+                sso_username:
+                  type: string
+                  default: ""
+                sso_password:
+                  type: string
+                  default: ""
+                sso_public_key:
+                  type: string
+                  default: ""
+                  description: leave empty for auto-generation
+                sso_bearer_only:
+                  type: string
+                  default: ""
+                sso_saml_keystore_secret:
+                  type: string
+                  default: "eap7-app-secret"
+                sso_saml_keystore:
+                  type: string
+                  default: "keystore.jks"
+                sso_saml_certificate_name:
+                  type: string
+                  default: "jboss"
+                sso_saml_keystore_password:
+                  type: string
+                  default: "mykeystorepass"
+                sso_secret:
+                  type: string
+                  description: leave empty for auto-generation
+                sso_enable_cors:
+                  type: string
+                  default: "false"
+                sso_saml_logout_page:
+                  type: string
+                  default: "/"
+                sso_disable_ssl_certificate_validation:
+                  type: string
+                  default: "true"
+                sso_truststore:
+                  type: string
+                  default: ""
+                sso_truststore_password:
+                  type: string
+                  default: ""
+                sso_truststore_secret:
+                  type: string
+                  default: "eap7-app-secret"
+                gc_max_metaspace_size:
+                  type: integer
+                  default: 512
+                max_post_size:
+                  type: string
+                  default: "4294967296"
+                db_database:
+                  type: string
+                  default: "mta"
+                postgresql_max_connections:
+                  type: string
+                  default: "200"
+                postgresql_shared_buffers:
+                  type: string
+                postgresql_cpu_request:
+                  type: string
+                  default: "0.5"
+                postgresql_mem_request:
+                  type: string
+                  default: "0.5Gi"
+                postgresql_cpu_limit:
+                  type: string
+                  default: "2"
+                postgresql_mem_limit:
+                  type: string
+                  default: "2Gi"
+                webLivenessInitialDelaySeconds:
+                  type: string
+                  default: "120"
+                webLivenessTimeoutSeconds:
+                  type: string
+                  default: "10"
+                webLivenessFailureThreshold:
+                  type: string
+                  default: "3"
+                webReadinessInitialDelaySeconds:
+                  type: string
+                  default: "120"
+                webReadinessTimeoutSeconds:
+                  type: string
+                  default: "10"
+                webReadinessFailureThreshold:
+                  type: string
+                  default: "3"
+                web_cpu_request:
+                  type: string
+                  default: "0.5"
+                web_mem_request:
+                  type: string
+                  default: "0.5Gi"
+                web_cpu_limit:
+                  type: string
+                  default: "4"
+                web_mem_limit:
+                  type: string
+                  default: "4Gi"
+                executor_cpu_request:
+                  type: string
+                  default: "0.5"
+                executor_mem_request:
+                  type: string
+                  default: "0.5Gi"
+                executor_cpu_limit:
+                  type: string
+                  default: "4"
+                executor_mem_limit:
+                  type: string
+                  default: "4Gi"
+                postgresql_image:
+                  type: string
+                  default: "centos/postgresql-96-centos7:latest"
+                web_readiness_probe:
+                  type: string
+                  default: "/bin/bash, -c, /opt/eap/bin/readinessProbe.sh"
+                web_liveness_probe:
+                  type: string
+                  default: "/bin/bash, -c, /opt/eap/bin/livenessProbe.sh"
+                executor_readiness_probe:
+                  type: string
+                  default: "/bin/bash, -c, /opt/mta-cli/bin/livenessProbe.sh"
+                executor_liveness_probe:
+                  type: string
+                  default: "/bin/bash, -c, /opt/mta-cli/bin/livenessProbe.sh"
+                executor_desired_replicas:
+                  type: integer
+                  default: 1
+                tls_secret:
+                  type: string
+                  default: ""
+              required:
+              - web_cpu_request
+              - web_mem_request
+              - executor_cpu_request
+              - executor_mem_request
+              - messaging_serializer
+              - mta_Volume_Capacity
+              - db_database
+              - volumeCapacity
+              - sso_url
+              - sso_realm
+              - docker_images_user
+              - docker_images_tag
+              - max_post_size
+              - executor_desired_replicas
+            status:
+              type: object
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+          required:
+          - spec
+
+

--- a/src/main/resources/operatorhub/mta-operator/0.0.5/metadata/annotations.yaml
+++ b/src/main/resources/operatorhub/mta-operator/0.0.5/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.package.v1: "mta-operator"
+  operators.operatorframework.io.bundle.channels.v1: "alpha"
+  operators.operatorframework.io.bundle.channel.default.v1: "alpha"
+  operators.operatorframework.io.bundle.mediatype.v1: "registry+v1"
+  operators.operatorframework.io.bundle.manifests.v1: "manifests/"
+  operators.operatorframework.io.bundle.metadata.v1: "metadata/"


### PR DESCRIPTION
Publish Operator in operatorhub for MTA 5.1.4
https://issues.redhat.com/browse/WINDUP-3046


Test case :

0. install Golang
0. clone  https://github.com/operator-framework/operator-registry ( if you haven't yet )
1. build it  ` cd operator-registry && make build`
2. it will generate `bin` folder with `opm` binary
2. clone this PR
1. create an Openshift 4.6.x environment and log to it with oc login ( find the command on ? in the web console )
1. podman pull quay.io/openshift-community-operators/catalog:latest
2. create and install catalog for version 0.0.4 , you should have this version already on your quay repository
./create-catalog.sh -u {your quayuser} -p {your quay pwd} -m 0.0.4 -b 0

3. install operator from the test catalog on namespace mta

4. create a new MTA instance

Expect:

1. when creating a new instance the MTA version on the field is defaulted to MTA 5.1.3.Final

Test Case :

1.create and install catalog for version 0.0.5, you will build current code
./create-catalog.sh -u {your quayuser} -p {your quay pwd} -m 0.0.5 -b 1

2. check that the installed operator will be upgraded to 0.0.5

3. delete the mta resource created before ( installed operators -> mta operator -> MTA instances -> :delete ) to free resources

4. create a new MTA instance

Expect:

1. when creating a new instance the MTA version on the field is defaulted to MTA 5.1.4.Final