### PR TITLE
[WINDUP-3270] - Upgrade MTA Web to use EAP 7.4

### DIFF
--- a/src/main/java/org/jboss/windup/operator/model/WindupResourceSpec.java
+++ b/src/main/java/org/jboss/windup/operator/model/WindupResourceSpec.java
@@ -59,6 +59,7 @@ public class WindupResourceSpec implements KubernetesResource {
     private String sso_truststore_secret;
     private String gc_max_metaspace_size;
     private String max_post_size;
+    private String sso_force_legacy_security;
     private String db_database;
     private String postgresql_max_connections;
     private String postgresql_shared_buffers;

--- a/src/main/java/org/jboss/windup/operator/util/WindupDeployment.java
+++ b/src/main/java/org/jboss/windup/operator/util/WindupDeployment.java
@@ -477,6 +477,7 @@ public class WindupDeployment {
             .addNewEnv().withName("SSO_TRUSTSTORE_PASSWORD").withValue(windupResource.getSpec().getSso_truststore_password()).endEnv()
             .addNewEnv().withName("GC_MAX_METASPACE_SIZE").withValue(windupResource.getSpec().getGc_max_metaspace_size()).endEnv()
             .addNewEnv().withName("MAX_POST_SIZE").withValue(windupResource.getSpec().getMax_post_size()).endEnv()
+            .addNewEnv().withName("SSO_FORCE_LEGACY_SECURITY").withValue(windupResource.getSpec().getSso_force_legacy_security()).endEnv()
           .endContainer()
           .addNewVolume()
             .withName(volume_mtaweb)

--- a/src/main/resources/k8s/def/windup.crd.yaml
+++ b/src/main/resources/k8s/def/windup.crd.yaml
@@ -157,6 +157,9 @@ spec:
                 max_post_size:
                   type: string
                   default: "4294967296"
+                sso_force_legacy_security:
+                  type: string
+                  default: "false"
                 db_database:
                   type: string
                   default: "mta"
@@ -254,6 +257,7 @@ spec:
                   - docker_images_user
                   - docker_images_tag
                   - max_post_size
+                  - sso_force_legacy_security
                   - executor_desired_replicas
             status:
               type: object

--- a/src/test/resources/windup-test.yaml
+++ b/src/test/resources/windup-test.yaml
@@ -27,6 +27,7 @@ spec:
   sso_url: /auth
   sso_realm: mta
   max_post_size: "4294967296"
+  sso_force_legacy_security: "false"
   db_password: pas345678
   db_username: userXYZ
   postgresql_cpu_request: "0.5"


### PR DESCRIPTION
Adding the SSO_FORCE_LEGACY_SECURITY ENV variable

## Steps to test this PR:

### Create a container image for the operator
- Check out this PR
- Create a container image for the operator using:

```
./mvnw clean package \
-Dquarkus.container-image.build=true \
-Dquarkus.container-image.registry=quay.io \
-Dquarkus.container-image.tag=windup-3270 \
-DskipTests
```

- The previous command should've created a container image called `quay.io/windupeng/windup-operator-native:windup-3270`
- Tag the previous container image to use your own username:
```
docker tag quay.io/windupeng/windup-operator-native:windup-3270 \
quay.io/YOUR_USERNAME/windup-operator-native:windup-3270
```
- Push the container image to your quay.io account.

### Deploy the operator (you need an OCP instance where you have cluster-admin permissions)

- Open the file `src/main/resources/k8s/def/windup.deployment.yaml` and replace the line 20 to point to your custom image. So 
`- image: quay.io/windupeng/windup-operator-native:latest` should become `- image: quay.io/YOUR_USERNAME/windup-operator-native:native:windup-3270`

- Create a namespace named `mta` (the name must be `mta`):

```
oc new-project mta
```

- Execute:
```
cd ./src/main/resources/k8s/def/
./script.create.all.sh
```

- Create a Windup instance:
```
oc create -f src/main/resources/k8s/examples/windup.yaml -n mta
```
- There should be a deployment called `mta-example` and the ENV variables of that deployment should contain the new ENV `SSO_FORCE_LEGACY_SECURITY` with value `false`

![Screenshot from 2022-03-03 10-29-47](https://user-images.githubusercontent.com/2582866/156536610-55776989-01e3-4b3e-8802-dfea3fd11b93.png)


That's all. We need to keep in mind that this PR only adds a new ENV variable to the deployment, it is not changing any core behaviour of the operator