### PR TITLE
WINDUP-3291 Moved to Postgresql 10

### DIFF
--- a/src/main/resources/k8s/def/windup.crd.yaml
+++ b/src/main/resources/k8s/def/windup.crd.yaml
@@ -224,7 +224,7 @@ spec:
                   default: "4Gi"
                 postgresql_image:
                   type: string
-                  default: "centos/postgresql-96-centos7:latest"
+                  default: "registry.redhat.io/rhel8/postgresql-10:1"
                 web_readiness_probe:
                   type: string
                   default: "/bin/bash, -c, /opt/eap/bin/readinessProbe.sh"


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3291

## Steps to test this PR:

### Create a container image for the operator
- Check out this PR
- Create a container image for the operator using:

```
./mvnw clean package \
-Dquarkus.container-image.build=true \
-Dquarkus.container-image.registry=quay.io \
-Dquarkus.container-image.tag=WINDUP-3291 \
-Dquarkus.container-image.group=${USER} \
-DskipTests -Pnative
```

- The previous command should've created a container image called `quay.io/${USER}/windup-operator-native:WINDUP-3291`
- [_Optional_] If your Quay.io username is different from ${USER}, then tag the previous container image to use your own username:
```
docker tag quay.io/${USER}/windup-operator-native:WINDUP-3291 \
quay.io/YOUR_USERNAME/windup-operator-native:WINDUP-3291
```
- Push the container image to your quay.io account.

### Deploy the operator (you need an OCP instance where you have cluster-admin permissions)

- Open the file `src/main/resources/k8s/def/windup.deployment.yaml` and replace the line 20 to point to your custom image. So 
`- image: quay.io/windupeng/windup-operator-native:latest` should become `- image: quay.io/YOUR_USERNAME/windup-operator-native:native:WINDUP-3291`

- Create a namespace named `mta` (the name must be `mta`):

```
oc new-project mta
```

- Execute:
```
cd ./src/main/resources/k8s/def/
./script.create.all.sh
```

- Create a Windup instance:
```
oc create -f src/main/resources/k8s/examples/windup.yaml -n mta
```

Test the MTA has been successfully deployed: if yes, run a test analyzing some sample applications with different configurations.