### PR TITLE
Fix the FIPS hardware encryption issue that doesn't allow Keycloak to start

### DIFF
--- a/src/main/java/org/jboss/windup/operator/model/WindupResourceSpec.java
+++ b/src/main/java/org/jboss/windup/operator/model/WindupResourceSpec.java
@@ -60,7 +60,7 @@ public class WindupResourceSpec implements KubernetesResource {
     private String gc_max_metaspace_size;
     private String max_post_size;
     private String sso_force_legacy_security;
-    private String java_opts_append;
+    private String java_opts;
     private String db_database;
     private String postgresql_max_connections;
     private String postgresql_shared_buffers;

--- a/src/main/java/org/jboss/windup/operator/model/WindupResourceSpec.java
+++ b/src/main/java/org/jboss/windup/operator/model/WindupResourceSpec.java
@@ -60,6 +60,7 @@ public class WindupResourceSpec implements KubernetesResource {
     private String gc_max_metaspace_size;
     private String max_post_size;
     private String sso_force_legacy_security;
+    private String java_opts_append;
     private String db_database;
     private String postgresql_max_connections;
     private String postgresql_shared_buffers;

--- a/src/main/java/org/jboss/windup/operator/util/WindupDeployment.java
+++ b/src/main/java/org/jboss/windup/operator/util/WindupDeployment.java
@@ -478,6 +478,7 @@ public class WindupDeployment {
             .addNewEnv().withName("GC_MAX_METASPACE_SIZE").withValue(windupResource.getSpec().getGc_max_metaspace_size()).endEnv()
             .addNewEnv().withName("MAX_POST_SIZE").withValue(windupResource.getSpec().getMax_post_size()).endEnv()
             .addNewEnv().withName("SSO_FORCE_LEGACY_SECURITY").withValue(windupResource.getSpec().getSso_force_legacy_security()).endEnv()
+            .addNewEnv().withName("JAVA_OPTS_APPEND").withValue(windupResource.getSpec().getSso_force_legacy_security()).endEnv()
           .endContainer()
           .addNewVolume()
             .withName(volume_mtaweb)

--- a/src/main/java/org/jboss/windup/operator/util/WindupDeployment.java
+++ b/src/main/java/org/jboss/windup/operator/util/WindupDeployment.java
@@ -478,7 +478,7 @@ public class WindupDeployment {
             .addNewEnv().withName("GC_MAX_METASPACE_SIZE").withValue(windupResource.getSpec().getGc_max_metaspace_size()).endEnv()
             .addNewEnv().withName("MAX_POST_SIZE").withValue(windupResource.getSpec().getMax_post_size()).endEnv()
             .addNewEnv().withName("SSO_FORCE_LEGACY_SECURITY").withValue(windupResource.getSpec().getSso_force_legacy_security()).endEnv()
-            .addNewEnv().withName("JAVA_OPTS_APPEND").withValue(windupResource.getSpec().getSso_force_legacy_security()).endEnv()
+            .addNewEnv().withName("JAVA_OPTS").withValue(windupResource.getSpec().getJava_opts()).endEnv()
           .endContainer()
           .addNewVolume()
             .withName(volume_mtaweb)

--- a/src/main/resources/k8s/def/windup.crd.yaml
+++ b/src/main/resources/k8s/def/windup.crd.yaml
@@ -160,7 +160,7 @@ spec:
                 sso_force_legacy_security:
                   type: string
                   default: "false"
-                java_opts_append:
+                java_opts:
                   type: string
                   default: "-Dcom.redhat.fips=false"
                 db_database:
@@ -261,7 +261,7 @@ spec:
                   - docker_images_tag
                   - max_post_size
                   - sso_force_legacy_security
-                  - java_opts_append
+                  - java_opts
                   - executor_desired_replicas
             status:
               type: object

--- a/src/main/resources/k8s/def/windup.crd.yaml
+++ b/src/main/resources/k8s/def/windup.crd.yaml
@@ -160,6 +160,9 @@ spec:
                 sso_force_legacy_security:
                   type: string
                   default: "false"
+                java_opts_append:
+                  type: string
+                  default: "-Dcom.redhat.fips=false"
                 db_database:
                   type: string
                   default: "mta"
@@ -258,6 +261,7 @@ spec:
                   - docker_images_tag
                   - max_post_size
                   - sso_force_legacy_security
+                  - java_opts_append
                   - executor_desired_replicas
             status:
               type: object

--- a/src/test/resources/windup-test.yaml
+++ b/src/test/resources/windup-test.yaml
@@ -28,6 +28,7 @@ spec:
   sso_realm: mta
   max_post_size: "4294967296"
   sso_force_legacy_security: "false"
+  java_opts_append: "-Dcom.redhat.fips=false"
   db_password: pas345678
   db_username: userXYZ
   postgresql_cpu_request: "0.5"

--- a/src/test/resources/windup-test.yaml
+++ b/src/test/resources/windup-test.yaml
@@ -28,7 +28,7 @@ spec:
   sso_realm: mta
   max_post_size: "4294967296"
   sso_force_legacy_security: "false"
-  java_opts_append: "-Dcom.redhat.fips=false"
+  java_opts: "-Dcom.redhat.fips=false"
   db_password: pas345678
   db_username: userXYZ
   postgresql_cpu_request: "0.5"


### PR DESCRIPTION
# Bug diagnosis
- Keycloak does not support FIPS mode enabled
- Every single Keycloak instance higher than >=15.1.0 will fail to run if the OS where it is running has FIPS enabled => hence JDK.
- We can not add users using `add-user-keycloak.sh` hence we can not init the `admin` user neither the `mta` user

A detailed explanation is being given at https://github.com/keycloak/keycloak/issues/9916

Useful links:
- https://access.redhat.com/solutions/5696401
- https://github.com/keycloak/keycloak/issues/9916
- https://github.com/quarkusio/quarkus-quickstarts/issues/998

# About this PR
Adding the JAVA_OPTS ENV variable

> Note: We are not using `JAVA_OPTS_APPEND` (as described in the Keycloak issue comments) but `JAVA_OPTS` otherwise the users `admin` neither `mta` will be created.

## Steps to test this PR:

### Create a container image for the operator
- Check out this PR
- Create a container image for the operator using:

```
./mvnw clean package \
-Dquarkus.container-image.build=true \
-Dquarkus.container-image.registry=quay.io \
-Dquarkus.container-image.tag=fips \
-DskipTests
```

- The previous command should've created a container image called `quay.io/windupeng/windup-operator-native:fips`
- Tag the previous container image to use your own username:
```
docker tag quay.io/windupeng/windup-operator-native:fips \
quay.io/YOUR_USERNAME/windup-operator-native:fips
```
- Push the container image to your quay.io account.

### Deploy the operator (you need an OCP instance where you have cluster-admin permissions)

- Open the file `src/main/resources/k8s/def/windup.deployment.yaml` and replace the line 20 to point to your custom image. So 
`- image: quay.io/windupeng/windup-operator-native:latest` should become `- image: quay.io/YOUR_USERNAME/windup-operator-native:native:fips`

- Create a namespace named `mta` (the name must be `mta`):

```
oc new-project mta
```

- Execute:
```
cd ./src/main/resources/k8s/def/
./script.create.all.sh
```

- Create a Windup instance:
```
oc create -f src/main/resources/k8s/examples/windup.yaml -n mta
```
- There should be a deployment called `mta-example` and the ENV variables of that deployment should contain the new ENV `JAVA_OPTS` with value `-Dcom.redhat.fips=false`



That's all. We need to keep in mind that this PR only adds a new ENV variable to the deployment, it is not changing any core behaviour of the operator