### PR TITLE
Revert build-helper-maven-plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,34 @@
                 <skipITs>false</skipITs>
                 <quarkus.package.type>native</quarkus.package.type>
             </properties>
+            <build>
+                <plugins>
+                    <!-- added to have the native "runner" application deployed as any other artifact -->
+                    <!-- DO NOT REMOVE THIS PLUGIN -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>3.3.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-artifacts</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>attach-artifact</goal>
+                                </goals>
+                                <configuration>
+                                    <artifacts>
+                                        <artifact>
+                                            <file>${project.build.directory}/${project.build.finalName}-runner</file>
+                                            <type>bin</type>
+                                        </artifact>
+                                    </artifacts>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Revert `build-helper-maven-plugin` configuration from:

- https://github.com/windup/windup-operator/pull/164
- https://github.com/windup/windup-operator/pull/183