### PR TITLE
[WINDUP-3996] - Operator exception when deploying windup

### DIFF
--- a/src/main/java/org/jboss/windup/operator/cdrs/v2alpha1/WebIngress.java
+++ b/src/main/java/org/jboss/windup/operator/cdrs/v2alpha1/WebIngress.java
@@ -14,7 +14,7 @@ import java.util.Map;
 @ApplicationScoped
 public class WebIngress extends WebIngressBase {
 
-    public static final String LABEL_SELECTOR = "app.kubernetes.io/managed-by=windup-operator,component=web";
+    public static final String LABEL_SELECTOR = "app.kubernetes.io/managed-by=windup-operator,component=web,component-variant=http";
 
     @Override
     @SuppressWarnings("unchecked")
@@ -24,7 +24,8 @@ public class WebIngress extends WebIngressBase {
                 context,
                 getIngressName(cr),
                 Map.of(
-                        "component", "web"
+                        "component", "web",
+                        "component-variant", "http"
                 ),
                 Map.of(
                         "console.alpha.openshift.io/overview-app-route", "true"

--- a/src/main/java/org/jboss/windup/operator/cdrs/v2alpha1/WebIngressSecure.java
+++ b/src/main/java/org/jboss/windup/operator/cdrs/v2alpha1/WebIngressSecure.java
@@ -16,7 +16,7 @@ import java.util.Map;
 @ApplicationScoped
 public class WebIngressSecure extends WebIngressBase {
 
-    public static final String LABEL_SELECTOR = "app.kubernetes.io/managed-by=windup-operator,component=web,component-variant=secure";
+    public static final String LABEL_SELECTOR = "app.kubernetes.io/managed-by=windup-operator,component=web,component-variant=https";
 
     @Override
     @SuppressWarnings("unchecked")
@@ -27,7 +27,7 @@ public class WebIngressSecure extends WebIngressBase {
                 getIngressName(cr),
                 Map.of(
                         "component", "web",
-                        "component-variant", "secure"
+                        "component-variant", "https"
                 ),
                 Collections.emptyMap()
         );


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3996

- The error generated in the log was happening because both ingresses had different labels. Making them both to have the same label keys fixed the issue